### PR TITLE
Твик скиллов Роботехника

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -197,6 +197,7 @@
 	                    SKILL_ANATOMY       = SKILL_ADEPT,
 						SKILL_CONSTRUCTION  = SKILL_BASIC,
 						SKILL_ELECTRICAL    = SKILL_BASIC,
+						SKILL_MEDICAL       = SKILL_ADEPT
 	                    SKILL_MECH          = HAS_PERK)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,


### PR DESCRIPTION
Роботехник не может вынуть мозг без нужного скилла медицины, по моему мнению - Роботехник не обладает нужным кол-вом скиллов для полного выполнения задач, т.е он не качая медицину - не может вынуть мозг, хотя Анатомия у него присутствует.

Проще говоря - Минимальный навык Роботехника в Медицине, повышен с Unskilled до Experienced ;; конечно это исключает теперь пару РП-процессов, к примеру: Звать хирурга на помощь вынуть мозг // Но в онлайн около 110 человек, я не думаю что это будет профитным вариантом.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

## Changelog
:cl:
tweak: базовые скиллы медика для роботиста
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
