### PR TITLE
Fix: patrol ship fixes, sierra crew fixes

### DIFF
--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -408,7 +408,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/patrol/crew/cargo)
@@ -806,7 +807,7 @@
 /obj/machinery/alarm/server{
 	dir = 4;
 	pixel_x = -22;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/dispenser/oxygen,
@@ -1071,7 +1072,8 @@
 /obj/machinery/power/apc/critical{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -1498,7 +1500,8 @@
 /obj/machinery/power/apc/super/critical{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 25
+	pixel_x = 25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet{
@@ -1577,7 +1580,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/patrol/crew/cargo)
@@ -1701,7 +1704,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
@@ -1743,7 +1746,8 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -1835,7 +1839,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -1882,7 +1887,8 @@
 "dx" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -1995,7 +2001,8 @@
 "dL" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/unary/heater{
 	dir = 8
@@ -2062,7 +2069,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -2144,7 +2151,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -2181,7 +2188,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/warning/secure_area{
@@ -2199,7 +2207,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/super/critical{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -2256,7 +2265,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/button/blast_door{
 	desc = "A remote control-switch for the torpedos launcher door.";
@@ -2287,7 +2297,8 @@
 /area/ship/patrol/command/lasers)
 "eq" = (
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2374,7 +2385,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2503,7 +2515,8 @@
 "eM" = (
 /obj/structure/flora/pottedplant/decorative,
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -3121,7 +3134,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/bed/sofa/black/left{
 	dir = 8
@@ -3292,7 +3306,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
@@ -3494,7 +3509,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list("ACCESS_ZEPPELIN")
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3642,7 +3657,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3699,7 +3715,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -3758,7 +3775,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/fore)
@@ -3820,7 +3838,8 @@
 "ht" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/aft)
@@ -3947,7 +3966,8 @@
 /obj/machinery/power/apc/super/critical{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 25
+	pixel_x = 25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/reaper)
@@ -4175,7 +4195,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/fore)
@@ -4387,7 +4407,8 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4736,7 +4757,8 @@
 /obj/machinery/alarm{
 	alarm_id = "xenobio3_alarm";
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -4798,7 +4820,8 @@
 "iX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -4953,7 +4976,8 @@
 "jj" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
@@ -5072,7 +5096,8 @@
 /obj/item/pen,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -5135,7 +5160,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -5148,7 +5174,8 @@
 /obj/machinery/power/apc/critical{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5412,7 +5439,8 @@
 /obj/machinery/power/apc/critical{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/folder/red,
@@ -5423,7 +5451,8 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/tiled/monotile,
@@ -5571,7 +5600,8 @@
 /obj/machinery/power/apc/super/critical{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 25
+	pixel_x = 25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -5587,7 +5617,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/port)
@@ -5670,7 +5701,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable{
@@ -5693,10 +5725,12 @@
 /obj/machinery/power/apc/critical{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -5836,7 +5870,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/port)
@@ -6109,7 +6144,8 @@
 "lv" = (
 /obj/machinery/alarm/server{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/flora/pottedplant/minitree,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -6492,7 +6528,8 @@
 	},
 /obj/machinery/power/apc/critical{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -6531,14 +6568,16 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "ml" = (
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/industrial/warning,
@@ -6692,7 +6731,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/flora/pottedplant/fern,
 /turf/simulated/floor/tiled,
@@ -6959,7 +6999,8 @@
 /obj/machinery/power/apc/critical{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -7075,7 +7116,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/engine/port)
@@ -7155,7 +7197,8 @@
 /area/ship/patrol/barracks/armory)
 "nw" = (
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/closet/secure_closet/guncabinet/patrol/assault,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -7436,7 +7479,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/item/stack/nanopaste,
 /obj/item/stack/nanopaste,
@@ -7608,7 +7652,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/fussion/control)
@@ -7773,7 +7818,8 @@
 /obj/machinery/power/apc/critical{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7912,7 +7958,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/critical{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/closet/secure_closet/guncabinet/patrol/energy,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -8145,7 +8192,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/critical{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -8172,7 +8220,8 @@
 "pt" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -8205,7 +8254,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/tiled,
@@ -8363,7 +8413,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "rI" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	name = "Better Hot Drinks machine";
+	prices = list()
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
 "rL" = (
@@ -8529,7 +8582,8 @@
 /area/ship/patrol/command/hangar)
 "yr" = (
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/computer/ship/navigation,

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -19,7 +19,8 @@
 /area/ship/patrol/maintenance/upper)
 "af" = (
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -79,7 +80,8 @@
 "an" = (
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/railing/mapped{
@@ -196,7 +198,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -239,7 +242,8 @@
 "az" = (
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/railing/mapped{
@@ -326,7 +330,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list("ACCESS_ZEPPELIN")
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -368,7 +372,8 @@
 "aN" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/item/stool,
 /turf/simulated/floor/plating,
@@ -592,7 +597,8 @@
 /obj/machinery/cryopod,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/cryo)
@@ -670,7 +676,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/upper)
@@ -827,7 +834,8 @@
 /obj/effect/floor_decal/corner/grey_alt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/upper/starboard)
@@ -847,7 +855,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -898,7 +907,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/brig)
@@ -1344,7 +1354,8 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1621,7 +1632,8 @@
 /obj/structure/ship_munition/disperser_charge/mining,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
@@ -1684,7 +1696,9 @@
 /area/ship/patrol/crew/hallway/upper/starboard)
 "ds" = (
 /obj/machinery/vending/coffee{
-	dir = 8
+	dir = 8;
+	name = "Better Hot Drinks machine";
+	prices = list()
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/ship/patrol/crew/hallway/upper/starboard)
@@ -1880,7 +1894,9 @@
 /area/ship/patrol/crew/hallway/upper/starboard)
 "dQ" = (
 /obj/machinery/vending/cigarette{
-	dir = 8
+	dir = 8;
+	name = "Better Cigarette machine";
+	prices = list()
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/ship/patrol/crew/hallway/upper/starboard)
@@ -1945,7 +1961,8 @@
 /obj/machinery/alarm{
 	alarm_id = "xenobio3_alarm";
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -1975,7 +1992,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -2049,7 +2067,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/catwalk,
@@ -2058,7 +2077,8 @@
 "ed" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2220,7 +2240,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(list(24,11))
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -2347,7 +2367,8 @@
 /obj/machinery/alarm{
 	alarm_id = "misc_research";
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/wood,
 /area/ship/patrol/maintenance/upper)
@@ -2387,7 +2408,8 @@
 "eK" = (
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2432,7 +2454,8 @@
 "eN" = (
 /obj/machinery/power/apc/critical{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/table/steel,
@@ -2542,11 +2565,17 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola{
+	name = "Better Robust Softdrinks";
+	prices = list()
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "fb" = (
-/obj/machinery/vending/snack,
+/obj/machinery/vending/snack{
+	name = "Better Getmore Chocolate Corp";
+	prices = list()
+	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
@@ -2578,17 +2607,22 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "fe" = (
-/obj/machinery/vending/coffee,
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
+/obj/machinery/vending/coffee{
+	dir = 2;
+	name = "Better Hot Drinks machine";
+	prices = list()
 	},
+/obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "ff" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	name = "Better Cigarette machine";
+	prices = list()
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -2655,7 +2689,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -2830,7 +2865,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
@@ -2895,7 +2931,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3075,7 +3112,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
@@ -3144,7 +3182,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/toilet)
@@ -3163,7 +3202,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/machinery/firealarm{
@@ -3181,7 +3221,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/upper)
@@ -3449,7 +3490,8 @@
 "gI" = (
 /obj/machinery/alarm{
 	dir = 0;
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/plating,
@@ -3601,7 +3643,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
@@ -3729,7 +3772,8 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
@@ -3746,7 +3790,8 @@
 "hl" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/machinery/vending/hydroseeds{
 	dir = 1
@@ -3821,7 +3866,8 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/item/material/kitchen/utensil/spoon{
@@ -3849,7 +3895,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/table/standard,
 /obj/item/storage/box/cups,
@@ -3902,7 +3949,8 @@
 /obj/machinery/light,
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/table/marble,
@@ -3942,7 +3990,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -3976,7 +4025,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -3993,7 +4043,8 @@
 "hG" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -4029,7 +4080,8 @@
 "hJ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/table/rack,
 /obj/structure/railing/mapped{
@@ -4129,7 +4181,8 @@
 "ma" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/railing/mapped{
 	dir = 1
@@ -4156,7 +4209,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
@@ -4380,7 +4434,8 @@
 "rV" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -4507,7 +4562,8 @@
 "uV" = (
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate/trashcart,
@@ -4843,7 +4899,8 @@
 "ET" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/port_gen/pacman,
@@ -4982,7 +5039,8 @@
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -5030,7 +5088,8 @@
 /obj/structure/catwalk,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
@@ -5148,7 +5207,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -5212,7 +5272,8 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/waste)
@@ -5282,7 +5343,8 @@
 /obj/structure/catwalk,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -22;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
@@ -5452,7 +5514,8 @@
 "UE" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)

--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -300,20 +300,20 @@
 /decl/hierarchy/outfit/job/patrol/engineer
 	name = PATROL_OUTFIT_JOB_NAME("Technician")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/engineering/away_solpatrol
-	belt = /obj/item/storage/belt/holster/general/away_solpatrol
+	belt = /obj/item/storage/belt/holster/security/away_solpatrol
 	gloves = /obj/item/clothing/gloves/insulated/black
 
 /decl/hierarchy/outfit/job/patrol/surgeon
 	name = PATROL_OUTFIT_JOB_NAME("Doctor")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/medical/away_solpatrol
-	belt = /obj/item/storage/belt/holster/general/away_solpatrol
+	belt = /obj/item/storage/belt/holster/security/away_solpatrol
 	gloves = /obj/item/clothing/gloves/latex/nitrile
 
 /decl/hierarchy/outfit/job/patrol/commander
 	name = PATROL_OUTFIT_JOB_NAME("Lieutenant Commander")
 	head = /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/officer/command/commander/away_solpatrol
-	belt = /obj/item/storage/belt/holster/general/away_solpatrol
+	belt = /obj/item/storage/belt/holster/security/away_solpatrol
 	id_types = list(/obj/item/card/id/awaycavalry/fleet/commander)
 	gloves = /obj/item/clothing/gloves/thick/duty/solgov/cmd
 
@@ -321,7 +321,7 @@
 	name = PATROL_OUTFIT_JOB_NAME("Ensign")
 	head = /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/officer/pilot1/away_solpatrol
-	belt = /obj/item/storage/belt/holster/general/away_solpatrol
+	belt = /obj/item/storage/belt/holster/security/away_solpatrol
 	gloves = /obj/item/clothing/gloves/thick/duty/rivalgloves
 
 #undef PATROL_OUTFIT_JOB_NAME

--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -96,7 +96,7 @@
 /obj/item/clothing/under/solgov/utility/army/urban/away_solpatrol/captain
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/rank/army/officer/o3)
 
-/obj/item/storage/belt/holster/general/away_solpatrol/New()
+/obj/item/storage/belt/holster/security/away_solpatrol/New()
 	..()
 	new /obj/item/gun/projectile/pistol/military(src)
 	new /obj/item/ammo_magazine/pistol/double(src)

--- a/maps/sierra/job/jobs_command.dm
+++ b/maps/sierra/job/jobs_command.dm
@@ -403,8 +403,8 @@
 	title = "Adjutant"
 	department = "Командный"
 	department_flag = SPT
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "Капитану и остальным главам"
 	selection_color = "#2f2f7f"
 	minimal_player_age = 18


### PR DESCRIPTION
## Changelog
:cl:
fix: changed belt that had no slots for mags to security belt for patrol crew
fix: removed price for products in patrol ship vending machines
tweak: increased number of adjuntans on Sierra from 2 to 3
fix: changed acces to APC and AirAlarms on patrol ship, to be accessable by crew
/:cl:

