### PR TITLE
Изменение количества НТ41 в оружейной со старта раунда

### DIFF
--- a/infinity/code/modules/clothing/glasses/glasses_xeno_veil.dm
+++ b/infinity/code/modules/clothing/glasses/glasses_xeno_veil.dm
@@ -15,6 +15,7 @@
 	icon = 'infinity/icons/obj/clothing/obj_eyes.dmi'
 	icon_state = "tajblind_med"
 	item_state = "tajblind_med"
+	off_state = "tajblind_med"
 	body_parts_covered = EYES
 
 /obj/item/clothing/glasses/sunglasses/sechud/tajblind
@@ -44,6 +45,7 @@
 	icon = 'infinity/icons/obj/clothing/obj_eyes.dmi'
 	icon_state = "tajvisor_med"
 	item_state = "tajvisor_med"
+	off_state = "tajvisor_med"
 	body_parts_covered = EYES
 
 /obj/item/clothing/glasses/sunglasses/sechud/tajvisor

--- a/maps/sierra/structures/closets/armory.dm
+++ b/maps/sierra/structures/closets/armory.dm
@@ -5,8 +5,8 @@
 	name = "submachine gun guncabinet"
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/smg/WillContain()
-	return list(/obj/item/gun/projectile/automatic/nt41 = 3,
-				/obj/item/ammo_magazine/n10mm = 9)
+	return list(/obj/item/gun/projectile/automatic/nt41 = 2,
+				/obj/item/ammo_magazine/n10mm = 6)
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/shotgun
 	name = "shotgun guncabinet"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

## Changelog
:cl:
Теперь в оружейной со старта не 3, а 2 НТ41, из-за того что всех девайсов там по 2, видимо число 2 магическое для оружейной.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
