### PR TITLE
feat: Psionics rebalance

### DIFF
--- a/code/modules/psionics/complexus/complexus_latency.dm
+++ b/code/modules/psionics/complexus/complexus_latency.dm
@@ -13,5 +13,5 @@
 	var/decl/psionic_faculty/faculty_decl = SSpsi.get_faculty(faculty)
 	to_chat(owner, SPAN_DANGER("You scream internally as your [faculty_decl.name] faculty is forced into operancy by [source]!"))
 	next_latency_trigger = world.time + rand(600, 1800) * new_rank
-	if(!redactive) owner.adjustBrainLoss(rand(trigger_strength * 2, trigger_strength * 4))
+	if(!redactive) owner.adjustBrainLoss(trigger_strength * 2)
 	return TRUE

--- a/code/modules/psionics/equipment/psimonitor.dm
+++ b/code/modules/psionics/equipment/psimonitor.dm
@@ -115,3 +115,24 @@
 
 /obj/machinery/psi_monitor/proc/report_violation(var/obj/item/implant/psi_control/implant, var/stress)
 	psi_violations += "Sigma [round(stress/10)] event - [implant.imp_in.name]."
+
+/obj/item/storage/briefcase/psi_monitor
+	name = "\improper Foundation briefcase"
+	desc = "A handsome black leather briefcase embossed with a stylized radio telescope."
+	icon_state = "fbriefcase"
+	item_state = "fbriefcase"
+	startswith = list(
+		/obj/item/implantcase/explosive = 2,
+		/obj/item/implantcase/tracking = 2,
+		/obj/item/implant/psi_control,
+		/obj/item/implanter/psi,
+		/obj/item/implanter,
+		/obj/item/implantpad,
+		)
+
+/obj/item/paper/psi_monitor
+	name = "Psi-monitor usage"
+	info = "<center><ntlogo></center><br><center><b>Руководство по использованию импланта пси-контроля</b><center><br><small>Настоящее руководство содержит сведения о должном использовании системы контроля псионических спобоностей, для старших сотрудников службы Защиты Активов объектов НаноТрейзен</small><br><br><b>Часть первая - имплант пси-контроля</b><br><br>Псионический имплант-подавитель класса L2 - последняя разработка Фонда Кучулейн для обеспечения контроля над особо опасными псиониками уровня мастера и выше.<br>Данный имплпант оборудован несколькими режимами работы:<br><br>Автоматический режим - осуществляет переключение между режимами, в зависимости от уровня тревоги на объекте.<br>Режим подавления - осуществляет активное подавление псионияеских способностей путём нарушения работы участков мозга, отвечающих за накопление псионической энергии. Также имеет дополнительную настройку: шоковый режим, посылающий крайне болезненный электрический импульс в мозг носителя при попытке применения пси-способностей.<br>Режим записи - отключение всех фукций импланта, за исключением записи попыток нарушения его работы через ЭМИ или хирургичекое вмешательство.<br><br><b>Часть вторая - монитор псионических имплантов</b><br><br>Согласно протоколу безопасности для объектов НаноТрейзен каждый объект должен быть оборудован монитором псионических имплантов, совместимым с имплантами класса L2. Данный монитор должен быть установлен в кабинете Главы Службы Безопасности Объекта, для управления установленными имплантами без необходимости хирургического удаления."
+	icon = 'maps/sierra/icons/obj/uniques.dmi'
+	icon_state = "paper_words"
+	stamps = "<HR><i>This paper has been stamped by the Central Command.</i>"

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -18972,6 +18972,7 @@
 /obj/random/date_based/christmas/xmaslights{
 	dir = 1
 	},
+/obj/item/folder/red,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/hos)
 "aFU" = (
@@ -20102,8 +20103,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/hos)
 "aHt" = (
-/obj/item/folder/red,
 /obj/structure/table/steel_reinforced,
+/obj/item/modular_computer/tablet/lease/preset/command,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/hos)
 "aHu" = (
@@ -21268,17 +21270,17 @@
 /area/bridge/hall/level_two)
 "aIZ" = (
 /obj/structure/table/steel,
-/obj/item/modular_computer/tablet/lease/preset/command,
 /obj/machinery/ai_status_display{
 	pixel_x = -32
 	},
-/obj/item/sticky_pad/random,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
+/obj/item/storage/briefcase/psi_monitor,
+/obj/item/paper/psi_monitor,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/hos)
 "aJa" = (


### PR DESCRIPTION
# Описание

Ребаланс урона по могзу от псионики при открытии Latent состояния. Добавление в кабинет ГСБ портфеля и инструкции с необходимыми имплантами для контроля.

## Основные изменения

feat: trigger rebalance
feat: case  and guide add
feat: case and guide placed on map

## Скриншоты



## Changelog

:cl:
feat: trigger rebalance
feat: case  and guide add
feat: case and guide placed on map
/:cl:
