### PR TITLE
add: Excavation Cycler in Petrov

### DIFF
--- a/maps/away_inf/yacht/yacht.dmm
+++ b/maps/away_inf/yacht/yacht.dmm
@@ -1041,15 +1041,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "ch" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
@@ -1057,11 +1051,22 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash/space,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "ci" = (
-/obj/machinery/power/solar_control,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/solar_control{
+	id = yachtsolar;
+	name = "Yacht Solar control";
+	track = 0
+	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -1136,7 +1141,6 @@
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cp" = (
-/obj/structure/table/steel,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/buildable/preset/yacht,
 /obj/structure/cable{
@@ -1157,15 +1161,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
-"cs" = (
-/obj/effect/floor_decal/solarpanel,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar,
-/turf/space,
-/area/yacht/engine)
 "ct" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
@@ -1179,37 +1174,36 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tracker,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
-/area/yacht/engine)
-"cv" = (
-/obj/effect/floor_decal/solarpanel,
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar,
-/turf/space,
 /area/yacht/engine)
 "cw" = (
 /obj/structure/lattice,
 /turf/space,
 /area/space)
 "cx" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/submap_landmark/spawnpoint/yachtman_spawn,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	dir = 4;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal{
 	dir = 1;
 	icon_state = "term"
@@ -1218,6 +1212,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cz" = (
@@ -1352,16 +1347,6 @@
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "cJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
@@ -1371,36 +1356,46 @@
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/airless,
-/area/yacht/engine)
-"cN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
-	dir = 4;
+	dir = 1;
 	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/airless,
+/area/yacht/engine)
+"cN" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
+	dir = 4;
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "cO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external/glass/bolted/cycling{
 	frequency = 1380;
 	id_tag = "solar_yacht_outer"
@@ -1411,15 +1406,24 @@
 	pixel_x = -9;
 	pixel_y = 23
 	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass/bolted/cycling{
+	frequency = 1380;
+	id_tag = "solar_yacht_outer"
+	},
+/obj/machinery/door/airlock/external/glass/bolted/cycling{
+	frequency = 1380;
+	id_tag = "solar_yacht_outer"
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/yacht/engine)
 "cP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1441,15 +1445,15 @@
 	tag_interior_door = "solar_yacht_inner"
 	},
 /obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/handrail{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/handrail{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cQ" = (
@@ -1457,7 +1461,6 @@
 	dir = 4;
 	icon_state = "intact"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external/glass/bolted/cycling{
 	frequency = 1380;
 	id_tag = "solar_yacht_inner"
@@ -1467,6 +1470,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cR" = (
@@ -1482,10 +1486,9 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 1;
 	d2 = 8;
-	dir = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
@@ -1788,20 +1791,21 @@
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
 "dt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/dust/corner,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "du" = (
@@ -2153,31 +2157,32 @@
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "ek" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	dir = 1;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "el" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/structure/railing/mapped,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/industrial/warning/dust,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/mapped,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "em" = (
@@ -2524,28 +2529,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
-"ip" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	dir = 4;
-	icon_state = "1-2"
-	},
-/obj/random/trash/space,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
-/area/yacht/engine)
 "kq" = (
 /obj/structure/table/marble,
 /obj/machinery/reagent_temperature/cooler{
@@ -2637,6 +2620,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/wall/r_titanium,
 /area/yacht/engine)
+"rf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	dir = 4;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	dir = 4;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash/space,
+/turf/simulated/floor/airless,
+/area/yacht/engine)
 "sg" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -2693,13 +2698,14 @@
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
 "yj" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
+	dir = 1;
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
@@ -2710,27 +2716,6 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_titanium,
-/area/yacht/engine)
-"zx" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	dir = 4;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
 /area/yacht/engine)
 "zA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2754,13 +2739,14 @@
 /turf/simulated/floor/carpet/purple,
 /area/yacht/living)
 "Ar" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
+	dir = 1;
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
@@ -2835,8 +2821,8 @@
 /turf/simulated/floor/carpet/green,
 /area/yacht/living)
 "Gq" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/toolcloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "Gu" = (
@@ -2860,28 +2846,6 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/yacht/engine)
-"Hz" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	dir = 4;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
 /area/yacht/engine)
 "HD" = (
 /obj/effect/paint/sun,
@@ -2910,19 +2874,20 @@
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
 "Jh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/item/storage/toolbox/electrical,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "Jy" = (
@@ -2960,6 +2925,12 @@
 /obj/effect/floor_decal/corner/darkblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
+"MB" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/solar,
+/obj/effect/floor_decal/solarpanel,
+/turf/simulated/floor/airless,
+/area/yacht/engine)
 "Ol" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -2975,23 +2946,23 @@
 /turf/simulated/floor/airless,
 /area/yacht/living)
 "Ot" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/trash/space,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
 "PD" = (
@@ -3063,80 +3034,38 @@
 /obj/effect/floor_decal/corner/darkblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
+"Uz" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/obj/effect/floor_decal/solarpanel,
+/turf/simulated/floor/airless,
+/area/yacht/engine)
 "UX" = (
 /obj/effect/wingrille_spawn/reinforced/full,
 /obj/machinery/door/firedoor,
 /obj/effect/paint/sun,
 /turf/simulated/floor/plating,
 /area/yacht/living)
-"WU" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+"YE" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	dir = 4;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
-/area/yacht/engine)
-"Yy" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
-	dir = 1;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
 	dir = 4;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
-/area/yacht/engine)
-"YA" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	dir = 1;
 	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	dir = 4;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
@@ -6169,13 +6098,13 @@ aa
 aa
 aa
 cw
-cs
-YA
-cv
+Uz
+YE
+MB
 aa
-cs
-Yy
-cv
+Uz
+YE
+MB
 cw
 aa
 aa
@@ -6271,13 +6200,13 @@ aa
 aa
 aa
 aa
-cs
-ip
-cv
+Uz
+YE
+MB
 aa
-cs
-zx
-cv
+Uz
+YE
+MB
 aa
 aa
 aa
@@ -6373,13 +6302,13 @@ aa
 aa
 aa
 cw
-cs
-zx
-cv
-cw
-cs
-zx
-cv
+Uz
+YE
+MB
+aa
+Uz
+rf
+MB
 cw
 aa
 aa
@@ -6475,13 +6404,13 @@ aa
 aa
 aa
 aa
-cs
-zx
-cv
+Uz
+YE
+MB
 aa
-cs
-zx
-cv
+Uz
+YE
+MB
 aa
 aa
 aa
@@ -6577,13 +6506,13 @@ aa
 aa
 aa
 cw
-cs
-zx
-cv
+Uz
+YE
+MB
 aa
-cs
-zx
-cv
+Uz
+YE
+MB
 cw
 aa
 aa
@@ -6679,13 +6608,13 @@ aa
 aa
 aa
 aa
-cs
-zx
-cv
-cw
-cs
-ip
-cv
+Uz
+YE
+MB
+aa
+Uz
+YE
+MB
 aa
 aa
 aa
@@ -6781,13 +6710,13 @@ aa
 aa
 aa
 cw
-cs
-zx
-cv
+Uz
+rf
+MB
 aa
-cs
-zx
-cv
+Uz
+YE
+MB
 cw
 aa
 aa
@@ -6883,13 +6812,13 @@ aa
 aa
 aa
 cw
-cs
-ip
-cv
+Uz
+YE
+MB
 aa
-cs
-zx
-cv
+Uz
+YE
+MB
 cw
 aa
 aa
@@ -6985,13 +6914,13 @@ aa
 aa
 aa
 cw
-cs
-zx
-cv
-cw
-cs
-zx
-cv
+Uz
+YE
+MB
+aa
+Uz
+YE
+MB
 cw
 aa
 aa
@@ -7087,13 +7016,13 @@ aa
 aa
 aa
 aa
-cs
-WU
-cv
+Uz
+YE
+MB
 aa
-cs
-Hz
-cv
+Uz
+YE
+MB
 aa
 aa
 aa

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -6075,6 +6075,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/purple/bordercorner2,
+/obj/machinery/suit_cycler/science,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/ship)
 "kg" = (


### PR DESCRIPTION
# Описание

* Добавил excavation cycler на Петров.
* Аномалисты скреллы/унати, смогут перешить риг под себя. Иногда нет возможности получить доступ к сайклеру шахтеров, и при попытке перешить excavation риг у ЭК, риг становится невидимым, ибо риг ссылается на \icons\obj\clothing\species\unathi\obj_suit_unathi.dmi, в то время как риг исследователей при перешивки под унати ссылается на \infinity\icons\obj\clothing\species\unathi\obj_suit_unathi.dmi. Та же ситуация и со скреллами.

## Основные изменения

* Добавлен excavation cycler на Петров