### PR TITLE
Shield for sierra

### DIFF
--- a/code/__defines/shields.dm
+++ b/code/__defines/shields.dm
@@ -2,8 +2,8 @@
 #define SHIELD_DAMTYPE_EM 2			// Electromagnetic damage - Ion weaponry, stun beams, ...
 #define SHIELD_DAMTYPE_HEAT 3		// Heat damage - Lasers, fire
 
-#define ENERGY_PER_HP (40 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
-#define ENERGY_UPKEEP_PER_TILE (3 KILOWATTS)	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
+#define ENERGY_PER_HP (30 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
+#define ENERGY_UPKEEP_PER_TILE (1 KILOWATTS)	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
 #define ENERGY_UPKEEP_IDLE 40                  // Base upkeep when idle; modified by other factors.
 
 #define MINOR_BREACH_THRESHOLD 99

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -71,7 +71,7 @@
 	max_energy = 0
 	full_shield_strength = 0
 	for(var/obj/item/stock_parts/smes_coil/S in component_parts)
-		full_shield_strength += (S.ChargeCapacity / CELLRATE) * 5
+		full_shield_strength += (S.ChargeCapacity / CELLRATE) / 20
 	max_energy = full_shield_strength * 20
 	current_energy = between(0, current_energy, max_energy)
 

--- a/maps/sierra/areas/sierra1.dm
+++ b/maps/sierra/areas/sierra1.dm
@@ -67,9 +67,6 @@
  * =================
  */
 
-/area/shield/thirddeck
-	name = "Third Deck - Shield Generator"
-
 	// Storage
 /area/storage/primary
 	name = "Third Deck - Primary Tool Storage"

--- a/maps/sierra/areas/sierra3.dm
+++ b/maps/sierra/areas/sierra3.dm
@@ -117,8 +117,6 @@
 	sound_env = SMALL_ENCLOSED
 	req_access = list(access_ai_upload)
 
-/area/shield/firstdeck
-	name = "First Deck - Shield Generator"
 	// Solars
 /area/maintenance/solar
 	name = "First Deck - Solar - Port"

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -684,24 +684,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shuttle/escape_pod/escape_pod1/station)
-"bE" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 10
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/thirddeck)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -710,11 +692,6 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "bG" = (
@@ -1359,13 +1336,8 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "cN" = (
@@ -1495,11 +1467,6 @@
 /area/quartermaster/expedition/storage)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/monitoring)
 "da" = (
@@ -1861,9 +1828,6 @@
 	icon_state = "cola";
 	name = "randomly spawned cola";
 	spawn_object = /obj/item/reagent_containers/food/drinks/cans/cola
-	},
-/obj/structure/sign/warning/high_voltage{
-	pixel_y = 32
 	},
 /obj/structure/railing/mapped{
 	dir = 4
@@ -2431,24 +2395,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/port)
 "eC" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Third Deck Shield Generator";
-	req_access = newlist()
+/turf/simulated/wall/r_wall/prepainted{
+	can_open = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/thirddeck)
+/area/maintenance/thirddeck/starboard)
 "eD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2567,15 +2517,15 @@
 /turf/simulated/floor/airless,
 /area/thruster/d3starboard)
 "eO" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/valve/shutoff/supply,
-/obj/structure/cable{
+/obj/structure/catwalk,
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
@@ -2587,11 +2537,6 @@
 	dir = 1
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "eR" = (
@@ -3143,25 +3088,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/ship)
-"fH" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/thirddeck)
 "fI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -3234,11 +3160,6 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/thirddeck/center)
 "fO" = (
@@ -3540,6 +3461,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "gl" = (
@@ -3579,7 +3505,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4021,11 +3947,6 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "ha" = (
@@ -4044,11 +3965,6 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "hc" = (
@@ -4577,22 +4493,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition)
 "hX" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Shield Generator - Third Deck"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/thirddeck)
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/starboard)
 "hY" = (
 /obj/effect/paint/nt_white,
 /obj/effect/paint_stripe/nt_red,
@@ -5574,15 +5479,6 @@
 "jv" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/forestarboard)
 "jw" = (
@@ -6296,15 +6192,6 @@
 "kw" = (
 /turf/simulated/wall/prepainted,
 /area/command/exploration_leader)
-"kx" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/forestarboard)
 "ky" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7900,13 +7787,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
 "mD" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "mE" = (
@@ -18876,20 +18758,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/petrov/ship)
 "Eg" = (
+/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 8
-	},
-/obj/machinery/atmospherics/valve/shutoff/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/thirddeck/center)
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "Eh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -20384,9 +20258,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
-"GI" = (
-/turf/simulated/wall/r_wall/hull,
-/area/shield/thirddeck)
 "GJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23628,7 +23499,7 @@
 /area/quartermaster/hangar)
 "LO" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/shield/thirddeck)
+/area/maintenance/thirddeck/starboard)
 "LP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24037,11 +23908,6 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/monitoring)
@@ -24962,16 +24828,8 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/entry2)
 "NX" = (
-/obj/machinery/power/shield_generator,
-/obj/effect/floor_decal/techfloor{
-	dir = 9
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/thirddeck)
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/starboard)
 "NY" = (
 /obj/structure/closet/emcloset{
 	anchored = 1;
@@ -26962,15 +26820,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aft)
 "Rs" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "Rt" = (
@@ -27850,11 +27703,6 @@
 "SS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/thirddeck/center)
 "ST" = (
@@ -27963,11 +27811,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/thirddeck/forestarboard)
 "Td" = (
@@ -28016,11 +27859,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/thirddeck/center)
 "Tg" = (
@@ -28731,11 +28569,6 @@
 /area/maintenance/thirddeck/port)
 "UR" = (
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "US" = (
@@ -28837,18 +28670,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
-"Vd" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/forestarboard)
 "Ve" = (
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -29173,16 +28994,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
 "VU" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
 	target_pressure = 200
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "VV" = (
@@ -30117,11 +29933,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/monitoring)
 "XS" = (
@@ -30177,15 +29988,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/corner,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/monitoring)
@@ -30377,15 +30183,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/expedition/storage)
 "Yt" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/vacant/monitoring)
 "Yu" = (
@@ -30465,15 +30266,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "YE" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "YH" = (
@@ -30600,15 +30396,10 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "YW" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "YX" = (
@@ -30825,11 +30616,6 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/monitoring)
 "ZA" = (
@@ -30904,7 +30690,7 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/techfloor,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -44655,7 +44441,7 @@ Is
 ax
 ax
 ax
-kx
+UR
 UR
 YE
 mD
@@ -44857,7 +44643,7 @@ Is
 ax
 ax
 dY
-Vd
+YE
 bq
 Xz
 br
@@ -46069,7 +45855,7 @@ Is
 WD
 eT
 St
-Rs
+Eg
 am
 am
 am
@@ -46473,7 +46259,7 @@ sN
 bv
 aB
 hM
-Eg
+SP
 SZ
 dz
 dz
@@ -49501,11 +49287,11 @@ Is
 Is
 Is
 Is
-GI
-GI
-GI
+ak
+ak
+ak
 NX
-bE
+NX
 LO
 dH
 gZ
@@ -49703,11 +49489,11 @@ Is
 Is
 Is
 Is
-GI
-GI
-GI
+ak
+ak
+ak
 hX
-fH
+NX
 eC
 bF
 hb
@@ -49905,9 +49691,9 @@ Is
 Is
 Is
 Is
-GI
-GI
-GI
+ak
+ak
+ak
 LO
 LO
 LO

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -5113,20 +5113,10 @@
 /turf/simulated/floor/wood/ebony,
 /area/crew_quarters/bar)
 "ajx" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Shield Generator - Second Deck"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/seconddeck)
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/foreport)
 "ajy" = (
 /obj/item/storage/bible/bible,
 /obj/item/storage/bible/bible,
@@ -6325,9 +6315,6 @@
 /obj/structure/table/wallf/steel{
 	dir = 4
 	},
-/obj/machinery/security_scanner{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/engineering/engineering_monitoring)
 "alJ" = (
@@ -6590,13 +6577,13 @@
 "amr" = (
 /obj/machinery/button/alternate/door/bolts{
 	dir = 4;
-	id_tag = "bar_room_two";
+	id_tag = "bar_room";
 	name = "Lock";
 	pixel_x = -24
 	},
 /obj/machinery/button/windowtint{
 	dir = 4;
-	id = "private_cafe_windows_2";
+	id = "private_cafe_windows";
 	pixel_x = -24;
 	pixel_y = 8;
 	range = 3
@@ -7026,10 +7013,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "amZ" = (
-/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
-	id = "private_cafe_windows_2"
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
+	id = "private_cafe_windows"
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/cafe)
 "ana" = (
@@ -8797,11 +8784,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "apR" = (
@@ -8845,11 +8827,6 @@
 	dir = 10
 	},
 /obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "apW" = (
@@ -9040,6 +9017,11 @@
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -9428,9 +9410,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/captain/office_anteroom)
 "ard" = (
-/obj/machinery/light/spot{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -9442,6 +9421,17 @@
 	},
 /obj/effect/floor_decal/corner/lime/bordercorner2{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -9836,8 +9826,8 @@
 "arZ" = (
 /obj/machinery/door/airlock/civilian{
 	dir = 4;
-	id_tag = "bar_room_two";
-	name = "Private Room Two"
+	id_tag = "bar_room";
+	name = "Private Room"
 	},
 /obj/random/date_based/christmas/doorwreath{
 	dir = 8
@@ -11340,12 +11330,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/center)
 "aut" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -11354,6 +11338,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "auu" = (
@@ -12119,6 +12105,11 @@
 /area/hallway/primary/seconddeck/center)
 "avz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "avB" = (
@@ -12835,9 +12826,6 @@
 /obj/random/date_based/christmas/doorwreath{
 	dir = 8
 	},
-/obj/machinery/security_scanner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engineering_monitoring)
 "awU" = (
@@ -13545,6 +13533,11 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -15827,14 +15820,28 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "aBM" = (
-/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
+/area/hallway/primary/seconddeck/center)
 "aBN" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/adherent)
@@ -16384,11 +16391,6 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
@@ -17238,23 +17240,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "aEh" = (
-/obj/structure/catwalk,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
+/turf/simulated/floor/tiled,
+/area/hallway/primary/seconddeck/center)
 "aEi" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/engineering{
+	name = "Shield Generator";
+	req_access = newlist()
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "aEj" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -17355,11 +17361,6 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/teleporter/seconddeck)
@@ -17500,15 +17501,6 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/compactor)
-"aEI" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
 "aEJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -17662,15 +17654,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
-"aEV" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/foreport)
 "aEW" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -18113,9 +18096,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
-"aFN" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/shield/seconddeck)
 "aFO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
@@ -18139,8 +18119,10 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/seconddeck)
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/foreport)
 "aFR" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/door/blast/regular{
@@ -18179,13 +18161,10 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/sleep/bunk)
 "aFV" = (
-/obj/machinery/power/shield_generator,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/seconddeck)
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/canister/empty/oxygen,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/foreport)
 "aFW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -18257,18 +18236,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "aGe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/seconddeck)
+/obj/structure/catwalk,
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/foreport)
 "aGf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -19993,18 +19964,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "aJq" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Third Deck Shield Generator";
-	req_access = newlist()
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/seconddeck)
+/obj/structure/catwalk,
+/obj/random/obstruction,
+/turf/simulated/floor/plating,
+/area/maintenance/seconddeck/foreport)
 "aJr" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/captain)
@@ -21108,11 +21072,6 @@
 "aLx" = (
 /obj/structure/catwalk,
 /obj/structure/ladder,
-/obj/structure/cable{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "32-2"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -21186,6 +21145,11 @@
 "aLG" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/center)
 "aLH" = (
@@ -22531,11 +22495,6 @@
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = 32
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "aNZ" = (
@@ -23342,10 +23301,11 @@
 /turf/simulated/wall/r_wall/hull,
 /area/crew_quarters/lounge)
 "aPE" = (
-/obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/table/rack,
+/obj/random/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "aPF" = (
@@ -24232,9 +24192,6 @@
 /turf/simulated/floor/plating,
 /area/vacant/gambling)
 "aRv" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -24247,6 +24204,13 @@
 /obj/effect/floor_decal/corner/lime/bordercorner2{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "aRx" = (
@@ -24377,11 +24341,6 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -30476,11 +30435,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/teleporter/seconddeck)
 "bcV" = (
@@ -31482,7 +31436,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "bfd" = (
-/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "bfe" = (
@@ -31797,7 +31751,7 @@
 /obj/effect/decal/cleanable/cobweb2{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/foreport)
 "bfO" = (
@@ -34647,6 +34601,11 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "enD" = (
@@ -34881,7 +34840,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/button/alternate/door/bolts{
 	dir = 8;
-	id_tag = "bar_room_two";
+	id_tag = "bar_room";
 	name = "Unlock";
 	pixel_x = 24;
 	pixel_y = 8;
@@ -35092,31 +35051,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
-"fop" = (
-/obj/machinery/door/airlock/civilian{
-	dir = 4;
-	id_tag = "bar_room_one";
-	name = "Private Room One"
-	},
-/obj/random/date_based/christmas/doorwreath{
-	dir = 8
-	},
-/obj/random/date_based/christmas/doorwreath{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/cafe)
 "foZ" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
@@ -35474,18 +35408,22 @@
 /turf/simulated/floor/airless,
 /area/space)
 "gHu" = (
-/obj/random/date_based/christmas/xmaslights{
-	dir = 4
-	},
-/obj/structure/bed/sofa/brown/right,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/obj/machinery/power/smes/buildable/preset/sierra/hangar{
+	RCon_tag = "Substation - Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "gIa" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -35603,6 +35541,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -36337,16 +36280,24 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/level1)
 "jma" = (
-/obj/structure/closet/walllocker{
-	pixel_y = 32
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/storage/candle_box/scented,
-/obj/structure/bed/sofa/brown/left,
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/obj/machinery/camera/network/engineering{
+	c_tag = "Shield Generator - Second Deck"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "jne" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/railing/mapped{
@@ -36366,12 +36317,8 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/cafe)
 "jny" = (
-/obj/effect/wallframe_spawn/reinforced/polarized/no_grille/regular{
-	id = "private_cafe_windows_1"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/crew_quarters/cafe)
+/turf/simulated/wall/r_wall/prepainted,
+/area/shield/seconddeck)
 "jqe" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -36605,6 +36552,11 @@
 	},
 /obj/effect/floor_decal/corner/lime/bordercorner2{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -37018,12 +36970,16 @@
 /turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/game_room)
 "lph" = (
-/obj/structure/bed/sofa/brown/left{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "lts" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -37251,6 +37207,11 @@
 /obj/effect/floor_decal/corner/lime/bordercorner2{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "mcx" = (
@@ -37415,21 +37376,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/game_room)
 "mCp" = (
-/obj/structure/flora/pottedplant/deskferntrim{
-	pixel_x = 5
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/random/date_based/christmas/xmaslights{
+/obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "mCE" = (
 /obj/random/date_based/christmas/xmaslights{
 	dir = 4
@@ -37786,6 +37747,11 @@
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -38684,48 +38650,38 @@
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/cafe)
 "qel" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
-"qff" = (
-/obj/machinery/button/windowtint{
-	dir = 4;
-	id = "private_cafe_windows_1";
-	pixel_x = -24;
-	pixel_y = 8;
-	range = 3
-	},
-/obj/machinery/button/alternate/door/bolts{
-	dir = 4;
-	id_tag = "bar_room_one";
-	name = "Lock";
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
 	pixel_x = -24
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
+"qff" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "qhX" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -38968,16 +38924,20 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/cafe)
 "qUo" = (
-/obj/item/paper/sierra,
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/turf/simulated/floor/plating,
+/area/shield/seconddeck)
 "qWx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -38990,6 +38950,11 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -39052,6 +39017,11 @@
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -39416,14 +39386,6 @@
 /turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/lounge_big)
 "sgI" = (
-/obj/machinery/button/alternate/door/bolts{
-	dir = 8;
-	id_tag = "bar_room_one";
-	name = "Unlock";
-	pixel_x = 24;
-	pixel_y = -8;
-	req_access = list("ACCESS_BAR")
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -39869,11 +39831,13 @@
 	pixel_x = -24
 	},
 /obj/machinery/light/small,
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/machinery/power/shield_generator,
+/obj/structure/cable,
+/obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "tfP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40155,21 +40119,14 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/cafe)
 "tPU" = (
-/obj/random/date_based/christmas/xmaslights{
-	dir = 4
-	},
-/obj/structure/bed/sofa/brown/right{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/purple,
-/area/crew_quarters/cafe)
+/obj/machinery/power/breakerbox{
+	RCon_tag = "Shield Generator Breaker Box"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shield/seconddeck)
 "tRJ" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -41009,6 +40966,11 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
 "wij" = (
@@ -41188,6 +41150,11 @@
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -41414,11 +41381,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/gym)
 "xwq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/cafe)
@@ -53028,7 +52998,7 @@ aRB
 ajx
 aGe
 aJq
-aEI
+aFs
 aPs
 aKj
 aHY
@@ -53227,9 +53197,9 @@ aCC
 aDt
 aEl
 aRB
-aFN
-aFN
-aFN
+aDS
+aDS
+aDS
 aNY
 aPz
 aKj
@@ -53432,7 +53402,7 @@ aRB
 aPB
 aJi
 aHY
-aEi
+aFs
 aFs
 aFs
 aFs
@@ -53631,10 +53601,10 @@ aRJ
 aCE
 bcU
 aEu
-aEI
+aFs
 aOQ
 aOV
-aEi
+aFs
 aFs
 aFs
 aPE
@@ -53833,10 +53803,10 @@ aRB
 aRB
 aRB
 aRB
-aEh
-aBM
-aBM
-aEV
+aFs
+aFs
+aFs
+aFs
 aFs
 bgk
 aKj
@@ -60279,11 +60249,11 @@ wQu
 arZ
 amq
 amq
-amq
-fop
-amq
-amq
-amq
+jny
+jny
+jny
+jny
+jny
 bOa
 kVL
 axD
@@ -60481,11 +60451,11 @@ wQu
 pmM
 amr
 qak
-amq
+jny
 qel
 qff
 tdE
-amq
+jny
 avB
 aus
 bag
@@ -60683,11 +60653,11 @@ wQu
 axX
 dec
 usq
-amq
+jny
 jma
 qUo
 lph
-amq
+aEi
 aRv
 aut
 aFz
@@ -60885,11 +60855,11 @@ wQu
 mCE
 jGl
 gOB
-amq
+jny
 gHu
 mCp
 tPU
-amq
+jny
 aqp
 aal
 aaF
@@ -61087,11 +61057,11 @@ wQu
 amZ
 amZ
 amZ
-amq
 jny
 jny
 jny
-amq
+jny
+jny
 ard
 bgt
 adX
@@ -61280,8 +61250,8 @@ sFP
 cHT
 ujh
 gYd
-aJR
-aMI
+aBM
+aEh
 ayi
 qWx
 aLG

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -3231,9 +3231,6 @@
 "agn" = (
 /turf/simulated/wall/prepainted,
 /area/medical/surgery/second)
-"ago" = (
-/turf/simulated/wall/r_wall/hull,
-/area/shield/firstdeck)
 "agp" = (
 /turf/simulated/open,
 /area/maintenance/firstdeck/centralstarboard)
@@ -3892,27 +3889,12 @@
 /obj/structure/closet/secure_closet/freezer/meat/bearcat,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
-"aht" = (
-/turf/simulated/wall/r_wall/prepainted,
-/area/shield/firstdeck)
-"ahu" = (
-/obj/structure/table/rack,
-/obj/structure/railing/mapped,
-/obj/random/maintenance,
-/turf/simulated/floor/tiled/techfloor,
-/area/shield/firstdeck)
 "ahv" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Shield Generator - First Deck"
-	},
 /obj/structure/table/rack,
 /obj/structure/railing/mapped,
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/techfloor,
-/area/shield/firstdeck)
-"ahw" = (
-/turf/simulated/wall/prepainted,
-/area/shield/firstdeck)
+/area/maintenance/firstdeck/centralstarboard)
 "ahx" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -4602,16 +4584,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "aiG" = (
-/obj/machinery/power/shield_generator,
 /obj/effect/floor_decal/techfloor{
 	dir = 9
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/firstdeck)
+/area/maintenance/firstdeck/centralstarboard)
 "aiH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4619,13 +4597,8 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/firstdeck)
+/area/maintenance/firstdeck/centralstarboard)
 "aiI" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -5294,10 +5267,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/staging)
 "ajN" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -24
@@ -5305,56 +5274,29 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/random/closet,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/firstdeck)
+/area/maintenance/firstdeck/centralstarboard)
 "ajO" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/firstdeck)
+/area/maintenance/firstdeck/centralstarboard)
 "ajP" = (
-/obj/machinery/door/airlock/engineering{
-	name = "First Deck Shield Generator";
-	req_access = newlist()
-	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shield/firstdeck)
+/area/maintenance/firstdeck/centralstarboard)
 "ajQ" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -57222,10 +57164,10 @@ aaa
 aam
 aaB
 aaB
-ago
-aht
-aht
-aht
+aaB
+xLj
+xLj
+xLj
 akU
 akU
 sMZ
@@ -57424,8 +57366,8 @@ aaa
 aam
 aaB
 aaB
-ago
-ahu
+aaB
+ahv
 aiG
 ajN
 akV
@@ -57626,7 +57568,7 @@ aaa
 aam
 aaB
 aaB
-ago
+aaB
 ahv
 aiH
 ajO
@@ -57828,9 +57770,9 @@ aaa
 aaB
 aaB
 aaB
-ago
-ahw
-ahw
+aaB
+agy
+agy
 ajP
 akV
 alR


### PR DESCRIPTION
# Описание

Меняем щитам циферки чтобы они были используемыми и добавляем в центр корабля комнату для щита. Теперь он один.

По результатом тестов щит в таком состоянии отлично держится под метеоритным обстрелом, очень медленно теряя свой заряд, с учетом постоянной подзарядки.

## Основные изменения

* Емкость щитов снижена в 100 раз.
* Энергопотребление щитов снижено в три раза.
* Урон по щитам снижен на 25%
* Добавлена отсек со щитом и смесом для него, прошлые отсеки превратились в техи.

# Скриншоты
Щит на третей палубе заменен на комнату со скрытой стеной, тайничок для антагов или что-то такое.
![изображение](https://user-images.githubusercontent.com/29740451/141996329-52453ff0-602b-4691-8bac-5a31c68fe234.png)
Щит на второй палубе заменен на очередной закаулок в техах, куда переехали стоящие без дела канистры
![изображение](https://user-images.githubusercontent.com/29740451/141996492-00f18ab7-31f1-4a15-ab73-b4338ccfa71e.png)
Щит на первой палубе - очередной закоулок
![изображение](https://user-images.githubusercontent.com/29740451/141996665-5cf37c1e-60ad-40a8-bfde-5f0aea567b26.png)
И наконец новая щитовая:
![изображение](https://user-images.githubusercontent.com/29740451/141996730-474a221e-39e3-4b42-bf8e-f2c31f51d03b.png)


## Changelog
:cl:
tweak: Щит теперь рассчитан на постоянную работу в активном режиме.
maptweak: На карту добавлен отсек со щитом, прошлые щитовые заменены техами.
/:cl:
