### PR TITLE
General server optimizations

### DIFF
--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -87,6 +87,9 @@ SUBSYSTEM_DEF(air)
 	var/active_zones = 0
 	var/next_id = 1
 
+	var/active_edges_firelimit = 20
+	var/times_failed_to_calc_firelevel = 0
+
 /datum/controller/subsystem/air/proc/reboot()
 	// Stop processing while we rebuild.
 	can_fire = FALSE
@@ -242,9 +245,25 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		else if (MC_TICK_CHECK)
 			return
 
+	var/halt_firelevel_calculations = 0
+	if(tick_usage * world.tick_lag > Master.current_ticklimit || length(processing_edges) > active_edges_firelimit)
+		halt_firelevel_calculations = 1
+		times_failed_to_calc_firelevel++
+		if(times_failed_to_calc_firelevel > 60)
+			active_edges_firelimit += 5
+			times_failed_to_calc_firelevel = 0
+	else
+		times_failed_to_calc_firelevel = 0
+
 	while (curr_fire.len)
 		var/zone/Z = curr_fire[curr_fire.len]
 		curr_fire.len--
+
+		if(halt_firelevel_calculations)
+			if(length(Z.fire_tiles) && !Z.firelevel)
+				Z.firelevel = vsc.fire_firelevel_multiplier
+		else
+			Z.calculate_fire_level()
 
 		Z.process_fire()
 

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -243,7 +243,7 @@ SUBSYSTEM_DEF(garbage)
 	var/type = D.type
 	var/refID = "\ref[D]"
 
-	del(D)
+	//del(D)
 
 	tick = (TICK_USAGE-tick+((world.time-ticktime)/world.tick_lag*100))
 

--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -23,12 +23,14 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 
 
 //This can be called if either we're doing whole sound setup ourselves or it will be as part of from-file sound setup
-/decl/sound_player/proc/PlaySoundDatum(var/atom/source, var/sound_id, var/sound/sound, var/range, var/prefer_mute, var/datum/client_preference/preference, streaming)
-	var/token_type = isnum(sound.environment) ? /datum/sound_token : /datum/sound_token/static_environment
-	return new token_type(source, sound_id, sound, range, prefer_mute, preference, streaming)
+/decl/sound_player/proc/PlaySoundDatum(var/atom/source, var/sound_id, var/sound/new_sound, var/range, var/prefer_mute, var/datum/client_preference/preference, streaming)
+	var/token_type = isnum(new_sound.environment) ? /datum/sound_token : /datum/sound_token/static_environment
+	return new token_type(source, sound_id, new_sound, range, prefer_mute, preference, streaming)
 
-/decl/sound_player/proc/PlayLoopingSound(var/atom/source, var/sound_id, var/sound, var/volume, var/range, var/falloff = 1, var/echo, var/frequency, var/prefer_mute, var/datum/client_preference/preference, streaming)
-	var/sound/S = istype(sound, /sound) ? sound : new(sound)
+/decl/sound_player/proc/PlayLoopingSound(var/atom/source, var/sound_id, var/_sound, var/volume, var/range, var/falloff = 1, var/echo, var/frequency, var/prefer_mute, var/datum/client_preference/preference, streaming)
+	if(!_sound)
+		return
+	var/sound/S = istype(_sound, /sound) ? _sound : new(_sound)
 	S.environment = 0 // Ensures a 3D effect even if x/y offset happens to be 0 the first time it's played
 	S.volume  = volume
 	S.falloff = falloff
@@ -39,7 +41,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	return PlaySoundDatum(source, sound_id, S, range, prefer_mute, preference, streaming)
 
 /decl/sound_player/proc/PrivStopSound(var/datum/sound_token/sound_token)
-	var/channel = sound_token.sound.channel
+	var/channel = sound_token._sound.channel
 	var/sound_id = sound_token.sound_id
 
 	var/sound_tokens = sound_tokens_by_sound_id[sound_id]
@@ -78,7 +80,7 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 	var/list/listeners // Assoc: Atoms hearing this sound, and their sound datum
 	var/range          // How many turfs away the sound will stop playing completely
 	var/prefer_mute    // If sound should be muted instead of stopped when mob moves out of range. In the general case this should be avoided because listeners will remain tracked.
-	var/sound/sound    // Sound datum, holds most sound relevant data
+	var/sound/_sound   // Sound datum, holds most sound relevant data
 	var/sound_id       // The associated sound id, used for cleanup
 	var/status = 0     // Paused, muted, running? Global for all listeners
 	var/listener_status// Paused, muted, running? Specific for the given listener.
@@ -89,34 +91,34 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 
 	var/datum/client_preference/preference
 
-/datum/sound_token/New(var/atom/source, var/sound_id, var/sound/sound, var/range = 4, var/prefer_mute = FALSE, var/datum/client_preference/preference, streaming)
+/datum/sound_token/New(var/atom/source, var/sound_id, var/sound/new_sound, var/range = 4, var/prefer_mute = FALSE, var/datum/client_preference/preference, streaming)
 	..()
 	if(!istype(source))
 		CRASH("Invalid sound source: [log_info_line(source)]")
-	if(!istype(sound))
-		CRASH("Invalid sound: [log_info_line(sound)]")
-	if(sound.repeat && !sound_id)
+	if(!istype(new_sound))
+		CRASH("Invalid sound: [log_info_line(new_sound)]")
+	if(new_sound.repeat && !sound_id)
 		CRASH("No sound id given")
-	if(!PrivIsValidEnvironment(sound.environment))
-		CRASH("Invalid sound environment: [log_info_line(sound.environment)]")
+	if(!PrivIsValidEnvironment(new_sound.environment))
+		CRASH("Invalid sound environment: [log_info_line(new_sound.environment)]")
 
 	src.prefer_mute = prefer_mute
 	src.range       = range
 	src.source      = source
-	src.sound       = sound
+	src._sound      = new_sound
 	src.sound_id    = sound_id
 	src.preference	= preference
 
 	if(streaming) //INF, Streams music
 		src.status |= SOUND_STREAM
 
-	if(sound.repeat) // Non-looping sounds may not reserve a sound channel due to the risk of not hearing when someone forgets to stop the token
+	if(new_sound.repeat) // Non-looping sounds may not reserve a sound channel due to the risk of not hearing when someone forgets to stop the token
 		var/channel = GLOB.sound_player.PrivGetChannel(src) //Attempt to find a channel
 		if(!isnum(channel))
 			CRASH("All available sound channels are in active use.")
-		sound.channel = channel
+		_sound.channel = channel
 	else
-		sound.channel = 0
+		_sound.channel = 0
 
 	listeners = list()
 	listener_status = list()
@@ -133,9 +135,9 @@ GLOBAL_DATUM_INIT(sound_player, /decl/sound_player, new)
 
 datum/sound_token/proc/SetVolume(var/new_volume)
 	new_volume = Clamp(new_volume, 0, 100)
-	if(sound.volume == new_volume)
+	if(_sound.volume == new_volume)
 		return
-	sound.volume = new_volume
+	_sound.volume = new_volume
 	PrivUpdateListeners()
 
 datum/sound_token/proc/Mute()
@@ -156,7 +158,7 @@ datum/sound_token/proc/Mute()
 		return
 	status |= SOUND_STOPPED
 
-	var/sound/null_sound = new(channel = sound.channel)
+	var/sound/null_sound = new(channel = _sound.channel)
 	for(var/listener in listeners)
 		PrivRemoveListener(listener, null_sound)
 	listeners = null
@@ -215,7 +217,7 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	PrivUpdateListenerLoc(listener, FALSE)
 
 /datum/sound_token/proc/PrivRemoveListener(var/atom/listener, var/sound/null_sound)
-	null_sound = null_sound || new(channel = sound.channel)
+	null_sound = null_sound || new(channel = _sound.channel)
 	sound_to(listener, null_sound)
 	GLOB.moved_event.unregister(listener, src, /datum/sound_token/proc/PrivUpdateListenerLoc)
 	GLOB.destroyed_event.unregister(listener, src, /datum/sound_token/proc/PrivRemoveListener)
@@ -224,6 +226,8 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 /datum/sound_token/proc/PrivUpdateListenerLoc(var/atom/listener, var/update_sound = TRUE)
 	var/turf/source_turf = get_turf(source)
 	var/turf/listener_turf = get_turf(listener)
+	if(!istype(source_turf) || !istype(listener_turf))
+		return
 
 	var/distance = get_dist(source_turf, listener_turf)
 	if(!listener_turf || (distance > range) || !(listener_turf in can_be_heard_from))
@@ -235,12 +239,12 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	else if(prefer_mute)
 		listener_status[listener] &= ~SOUND_MUTE
 
-	sound.x = source_turf.x - listener_turf.x
-	sound.z = source_turf.y - listener_turf.y
-	sound.y = 1
+	_sound.x = source_turf.x - listener_turf.x
+	_sound.z = source_turf.y - listener_turf.y
+	_sound.y = 1
 	// Far as I can tell from testing, sound priority just doesn't work.
 	// Sounds happily steal channels from each other no matter what.
-	sound.priority = Clamp(255 - distance, 0, 255)
+	_sound.priority = Clamp(255 - distance, 0, 255)
 	PrivUpdateListener(listener, update_sound)
 
 /datum/sound_token/proc/PrivUpdateListeners()
@@ -252,15 +256,15 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 		PrivRemoveListener(listener)
 		return
 
-	sound.environment = PrivGetEnvironment(listener)
-	sound.status = status|listener_status[listener]
+	_sound.environment = PrivGetEnvironment(listener)
+	_sound.status = status|listener_status[listener]
 	if(update_sound)
-		sound.status |= SOUND_UPDATE
-	sound_to(listener, sound)
+		_sound.status |= SOUND_UPDATE
+	sound_to(listener, _sound)
 
 /datum/sound_token/proc/PrivGetEnvironment(var/listener)
 	var/area/A = get_area(listener)
-	return A && PrivIsValidEnvironment(A.sound_env) ? A.sound_env : sound.environment
+	return A && PrivIsValidEnvironment(A.sound_env) ? A.sound_env : _sound.environment
 
 // Checking if client want to hear it
 /datum/sound_token/proc/check_preference(atom/listener)
@@ -279,11 +283,11 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	return TRUE
 
 /datum/sound_token/static_environment/PrivGetEnvironment()
-	return sound.environment
+	return _sound.environment
 
 /obj/sound_test
-	var/sound = 'sound/misc/TestLoop1.ogg'
+	var/_sound = 'sound/misc/TestLoop1.ogg'
 
 /obj/sound_test/New()
 	..()
-	GLOB.sound_player.PlayLoopingSound(src, /obj/sound_test, sound, 50, 3)
+	GLOB.sound_player.PlayLoopingSound(src, /obj/sound_test, _sound, 50, 3)

--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -3,6 +3,8 @@
 #define LIGHT 2
 #define ENVIRON 3
 */
+/area
+	var/list/machinery_list
 
 /area/proc/powered(var/chan)		// return true if the area has power to given channel
 	if(!requires_power)
@@ -23,7 +25,7 @@
 
 // called when power status changes
 /area/proc/power_change()
-	for(var/obj/machinery/M in src)	// for each machine in the area
+	for(var/obj/machinery/M in machinery_list)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
 	if (fire || eject || party)
 		update_icon()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -133,19 +133,25 @@ Class Procs:
 	RefreshParts()
 	power_change()
 
+	var/area/A = get_area(src)
+	if(A)
+		LAZYADD(A.machinery_list, src)
+
 /obj/machinery/Destroy()
 	if(istype(wires))
 		QDEL_NULL(wires)
 	SSmachines.machinery -= src
 	QDEL_NULL_LIST(component_parts) // Further handling is done via destroyed events.
 	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_ALL)
+	var/area/A = get_area(src)
+	if(A)
+		LAZYREMOVE(A.machinery_list, src)
 	. = ..()
 
 /obj/machinery/proc/ProcessAll(var/wait)
 	if(processing_flags & MACHINERY_PROCESS_COMPONENTS)
-		for(var/thing in processing_parts)
-			var/obj/item/stock_parts/part = thing
-			if(part.machine_process(src) == PROCESS_KILL)
+		for(var/obj/item/stock_parts/part as anything in processing_parts)
+			if(istype(part) && part.machine_process(src) == PROCESS_KILL)
 				part.stop_processing()
 
 	if((processing_flags & MACHINERY_PROCESS_SELF) && Process(wait) == PROCESS_KILL)
@@ -480,3 +486,11 @@ Class Procs:
 
 /obj/machinery/proc/on_user_login(mob/M)
 	return
+
+/obj/machinery/wrench_floor_bolts(mob/user, delay)
+	. = ..()
+	var/area/A = get_area(src)
+	if(anchored)
+		A.machinery_list |= src
+	else
+		A.machinery_list -= src

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -73,10 +73,12 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 				T.ex_act(dist)
 				if(!T)
 					T = locate(x0,y0,z0)
-				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
-					var/atom/movable/AM = atom_movable
+				for(var/atom/movable/AM as anything in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 					if(AM && AM.simulated && !T.protects_atom(AM))
 						AM.ex_act(dist)
+					CHECK_TICK
+
+				CHECK_TICK
 
 		sleep(8)
 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -65,7 +65,6 @@
 
 /obj/structure/railing/Destroy()
 	anchored = FALSE
-	atom_flags = 0
 	broken = TRUE
 	for(var/thing in trange(1, src))
 		var/turf/T = thing

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -41,17 +41,16 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		create_fire(exposed_temperature)
 	return igniting
 
-/zone/proc/process_fire()
+/zone/proc/calculate_fire_level()
 	var/datum/gas_mixture/burn_gas = air.remove_ratio(vsc.fire_consuption_rate, fire_tiles.len)
-
-	var/firelevel = burn_gas.react(src, fire_tiles, force_burn = 1, no_check = 1)
-
+	firelevel = burn_gas.react(src, fire_tiles, force_burn = 1, no_check = 1)
 	air.merge(burn_gas)
 
+/zone/proc/process_fire()
 	if(firelevel)
 		for(var/turf/T in fire_tiles)
 			if(T.fire)
-				T.fire.firelevel = firelevel
+				T.fire.update_firelevel(firelevel)
 			else
 				var/obj/effect/decal/cleanable/liquid_fuel/fuel = locate() in T
 				fire_tiles -= T
@@ -98,7 +97,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		return 1
 
 	if(fire)
-		fire.firelevel = max(fl, fire.firelevel)
+		fire.update_firelevel(max(fl, fire.firelevel))
 		return 1
 
 	if(!zone)
@@ -140,22 +139,12 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 	var/datum/gas_mixture/air_contents = my_tile.return_air()
 
-	if(firelevel > 6)
-		icon_state = "3"
-		set_light(1, 2, 7)
-	else if(firelevel > 2.5)
-		icon_state = "2"
-		set_light(0.7, 2, 5)
-	else
-		icon_state = "1"
-		set_light(0.5, 1, 3)
-
 	for(var/mob/living/L in loc)
 		L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())  //Burn the mobs!
 
-	loc.fire_act(air_contents, air_contents.temperature, air_contents.volume)
-	for(var/atom/A in loc)
+	for(var/atom/A in (loc.contents + loc))
 		A.fire_act(air_contents, air_contents.temperature, air_contents.volume)
+
 
 	//spread
 	for(var/direction in GLOB.cardinal)
@@ -166,16 +155,16 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 				if(!enemy_tile.zone || enemy_tile.fire)
 					continue
 
+				//If extinguisher mist passed over the turf it's trying to spread to, don't spread and
+				//reduce firelevel.
+				if(enemy_tile.fire_protection > world.time-30)
+					update_firelevel(firelevel - 1.5)
+					continue
+
 				//if(!enemy_tile.zone.fire_tiles.len) TODO - optimize
 				var/datum/gas_mixture/acs = enemy_tile.return_air()
 				var/obj/effect/decal/cleanable/liquid_fuel/liquid = locate() in enemy_tile
 				if(!acs || !acs.check_combustability(liquid))
-					continue
-
-				//If extinguisher mist passed over the turf it's trying to spread to, don't spread and
-				//reduce firelevel.
-				if(enemy_tile.fire_protection > world.time-30)
-					firelevel -= 1.5
 					continue
 
 				//Spread the fire.
@@ -186,7 +175,6 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 				enemy_tile.adjacent_fire_act(loc, air_contents, air_contents.temperature, air_contents.volume)
 
 	animate(src, color = fire_color(air_contents.temperature), 5)
-	set_light(l_color = color)
 
 /obj/fire/New(newLoc,fl)
 	..()
@@ -199,10 +187,24 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 	var/datum/gas_mixture/air_contents = loc.return_air()
 	color = fire_color(air_contents.temperature)
-	set_light(0.5, 1, 3, l_color = color)
 
-	firelevel = fl
+	update_firelevel(fl)
 	SSair.active_hotspots.Add(src)
+
+/obj/fire/proc/update_firelevel(var/new_firelevel)
+	var/old_firelevel = firelevel
+
+	if(new_firelevel <= 2.5 && old_firelevel > 2.5)
+		icon_state = "1"
+		set_light(0.5, 1, 3, l_color = color)
+	else if(new_firelevel <= 6 && old_firelevel > 6)
+		icon_state = "2"
+		set_light(0.7, 2, 5, l_color = color)
+	else if(new_firelevel > 6 && old_firelevel <= 6)
+		icon_state = "3"
+		set_light(1, 2, 7, l_color = color)
+
+	firelevel = new_firelevel
 
 /obj/fire/proc/fire_color(var/env_temperature)
 	var/temperature = max(4000*sqrt(firelevel/vsc.fire_firelevel_multiplier), env_temperature)
@@ -220,6 +222,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 /turf/proc/apply_fire_protection()
 /turf/simulated/apply_fire_protection()
 	fire_protection = world.time
+
 
 //Returns the firelevel
 /datum/gas_mixture/proc/react(zone/zone, force_burn, no_check = 0)
@@ -247,7 +250,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 		//Liquid Fuel
 		var/fuel_area = 0
-		if(zone)
+		if(zone && length(zone.fuel_objs))
 			for(var/obj/effect/decal/cleanable/liquid_fuel/fuel in zone.fuel_objs)
 				liquid_fuel += fuel.amount*LIQUIDFUEL_AMOUNT_TO_MOL
 				fuel_area++
@@ -292,7 +295,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 
 		//if the reaction is progressing too slow then it isn't self-sustaining anymore and burns out
 		if(zone) //be less restrictive with canister and tank reactions
-			if((!liquid_fuel || used_fuel <= FIRE_LIQUD_MIN_BURNRATE) && (!gas_fuel || used_fuel <= FIRE_GAS_MIN_BURNRATE*zone.contents.len))
+			if((!liquid_fuel || used_fuel <= FIRE_LIQUD_MIN_BURNRATE) && (!gas_fuel || used_fuel <= FIRE_GAS_MIN_BURNRATE*length(zone.contents)))
 				return 0
 
 
@@ -308,8 +311,7 @@ turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
 		for(var/g in burned_fuel.gas)
 			adjust_gas(gas_data.burn_product[g], burned_fuel.gas[g])
 
-		if(zone)
-			zone.remove_liquidfuel(used_liquid_fuel, !check_combustability())
+		zone?.remove_liquidfuel(used_liquid_fuel, !check_combustability())
 
 		//calculate the energy produced by the reaction and then set the new temperature of the mix
 		temperature = (starting_energy + vsc.fire_fuel_energy_release * (used_gas_fuel + used_liquid_fuel)) / heat_capacity()

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -52,6 +52,7 @@ Class Procs:
 	var/list/graphic_add = list()
 	var/list/graphic_remove = list()
 	var/last_air_temperature = TCMB
+	var/firelevel = 0
 
 /zone/New()
 	SSair.add_zone(src)
@@ -146,7 +147,7 @@ Class Procs:
 /zone/proc/tick()
 
 	// Update fires.
-	if(air.temperature >= PHORON_FLASHPOINT && !(src in SSair.active_fire_zones) && air.check_combustability() && contents.len)
+	if(air.temperature >= PHORON_FLASHPOINT && !(src in SSair.active_fire_zones) && length(contents) && air.check_combustability())
 		var/turf/T = pick(contents)
 		if(istype(T))
 			T.create_fire(vsc.fire_firelevel_multiplier)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -127,7 +127,6 @@
 	var/is_critical = 0
 	var/global/status_overlays = 0
 	var/failure_timer = 0               // Cooldown thing for apc outage event
-	var/force_update = 0
 	var/emp_hardened = 0
 	var/global/list/status_overlays_lock
 	var/global/list/status_overlays_charging
@@ -218,6 +217,8 @@
 	failure_timer = max(failure_timer, round(duration))
 	if(needs_powerdown_sound == TRUE) //INF
 		playsound(src, 'sound/machines/apc_nopower.ogg', 75, 0)
+	update()
+	queue_icon_update()
 
 /obj/machinery/power/apc/proc/init_round_start()
 	has_electronics = 2 //installed and secured
@@ -1011,11 +1012,11 @@ INF */
 		return
 
 	if(failure_timer)
-		update()
-		queue_icon_update()
 		failure_timer--
-		force_update = 1
-		return
+		if(!failure_timer)
+			update()
+			queue_icon_update()
+		else return
 
 	lastused_light = (lighting >= POWERCHAN_ON) ? area.usage(LIGHT) : 0
 	lastused_equip = (equipment >= POWERCHAN_ON) ? area.usage(EQUIP) : 0
@@ -1064,8 +1065,7 @@ INF */
 	update_channels()
 
 	// update icon & area power if anything changed
-	if(last_lt != lighting || last_eq != equipment || last_en != environ || force_update)
-		force_update = 0
+	if(last_lt != lighting || last_eq != equipment || last_en != environ)
 		queue_icon_update()
 		update()
 	else if (last_ch != charging)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -74,7 +74,7 @@
 	var/grav_pulling = 0
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
 	var/pull_time = 300
-	var/explosion_power = 9
+	var/explosion_power = 20
 
 	var/emergency_issued = 0
 

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -208,6 +208,7 @@
 
 	// Effect 1: Radiation, weakening to all mobs on Z level
 	for(var/z in affected_z)
+		CHECK_TICK
 		SSradiation.z_radiate(locate(1, 1, z), DETONATION_RADS, 1)
 
 	for(var/mob/living/mob in GLOB.living_mob_list_)
@@ -217,6 +218,8 @@
 		if(!(TM.z in affected_z))
 			continue
 
+		CHECK_TICK
+
 		mob.Weaken(DETONATION_MOB_CONCUSSION)
 		to_chat(mob, SPAN_DANGER("An invisible force slams you against the ground!"))
 
@@ -224,6 +227,8 @@
 	for(var/obj/machinery/power/apc/A in SSmachines.machinery)
 		if(!(A.z in affected_z))
 			continue
+
+		CHECK_TICK
 
 		// Overloads lights
 		if(prob(DETONATION_APC_OVERLOAD_PROB))
@@ -235,9 +240,13 @@
 		else
 			A.energy_fail(round(DETONATION_SHUTDOWN_APC * random_change))
 
+	CHECK_TICK
+
 	for(var/obj/machinery/power/smes/buildable/S in SSmachines.machinery)
 		if(!(S.z in affected_z))
 			continue
+
+		CHECK_TICK
 		// Causes SMESes to shut down for a bit
 		var/random_change = rand(100 - DETONATION_SHUTDOWN_RNG_FACTOR, 100 + DETONATION_SHUTDOWN_RNG_FACTOR) / 100
 		S.energy_fail(round(DETONATION_SHUTDOWN_SMES * random_change))
@@ -247,10 +256,12 @@
 	for(var/obj/machinery/power/solar/S in SSmachines.machinery)
 		if(!(S.z in affected_z))
 			continue
+		CHECK_TICK
 		if(prob(DETONATION_SOLAR_BREAK_CHANCE))
 			S.set_broken(TRUE)
 
 
+	CHECK_TICK
 
 	// Effect 4: Medium scale explosion
 	spawn(0)

--- a/code/modules/synthesized_instruments/sound_token.dm
+++ b/code/modules/synthesized_instruments/sound_token.dm
@@ -6,20 +6,20 @@
 	var/datum/sound_player/player
 
 //Slight duplication, but there's key differences
-/datum/sound_token/instrument/New(var/atom/source, var/sound_id, var/sound/sound, var/range = 4, var/prefer_mute = FALSE, var/use_env, var/datum/sound_player/player)
+/datum/sound_token/instrument/New(var/atom/source, var/sound_id, var/sound/new_sound, var/range = 4, var/prefer_mute = FALSE, var/use_env, var/datum/sound_player/player)
 	if(!istype(source))
 		CRASH("Invalid sound source: [log_info_line(source)]")
-	if(!istype(sound))
-		CRASH("Invalid sound: [log_info_line(sound)]")
-	if(sound.repeat && !sound_id)
+	if(!istype(new_sound))
+		CRASH("Invalid sound: [log_info_line(new_sound)]")
+	if(new_sound.repeat && !sound_id)
 		CRASH("No sound id given")
-	if(!PrivIsValidEnvironment(sound.environment))
-		CRASH("Invalid sound environment: [log_info_line(sound.environment)]")
+	if(!PrivIsValidEnvironment(new_sound.environment))
+		CRASH("Invalid sound environment: [log_info_line(new_sound.environment)]")
 
 	src.prefer_mute = prefer_mute
 	src.range       = range
 	src.source      = source
-	src.sound       = sound
+	src._sound      = new_sound
 	src.sound_id    = sound_id
 	src.use_env = use_env
 	src.player = player
@@ -27,7 +27,7 @@
 	var/channel = GLOB.sound_player.PrivGetChannel(src) //Attempt to find a channel
 	if(!isnum(channel))
 		CRASH("All available sound channels are in active use.")
-	sound.channel = channel
+	_sound.channel = channel
 
 	listeners = list()
 	listener_status = list()
@@ -40,10 +40,10 @@
 /datum/sound_token/instrument/PrivGetEnvironment(var/listener)
 	//Allow override (in case your instrument has to sound funky or muted)
 	if(use_env)
-		return sound.environment
+		return _sound.environment
 	else
 		var/area/A = get_area(listener)
-		return A && PrivIsValidEnvironment(A.sound_env) ? A.sound_env : sound.environment
+		return A && PrivIsValidEnvironment(A.sound_env) ? A.sound_env : _sound.environment
 
 
 datum/sound_token/instrument/PrivAddListener(var/atom/listener)

--- a/infinity/code/modules/power/lighting.dm
+++ b/infinity/code/modules/power/lighting.dm
@@ -40,6 +40,10 @@ UPDATE_ENVIROMENT_SOUND_MACRO_INHERITER(/obj/machinery/light/remove_bulb())
 	else
 		QDEL_NULL(sound_token)
 
+/obj/machinery/light/Destroy()
+	QDEL_NULL(sound_token)
+	return ..()
+
 /obj/item/light
 	var/enviroment_sound
 	var/enviroment_sound_range = 3


### PR DESCRIPTION
Исправлены рантайм эрроры связанные с удалением перилл и вызовом зацикленных звуков.

Оптимизирована обработка списка машинерии по зонам, оптимизирован вызов update() у APC 

Убран бьендовский del() из HardDel() сборщика мусора, так как это очень ЦПУ-затратная функция, суть которой в сохранении лишних 10мб оперативной памяти (которой в запасе еще как минимум 2ГБ)

Плавность взрыва суперматерии и взрывов в целом улучшена, теперь сервер не будет виснуть намертво, пока взрыв не обработается. Мощность взрыва суперматерии возвращена до старых значений.

Оптимизирована обработка пожаров. Пожары, прежде, чем заниматься расчетами выжигания газа из их зоны, будут ждать, пока не обработается большая часть разгерметизаций. Эта переработка связана с тем, что при взрыве суперматерии множественные обновления зон вместе с обработкой пожаров вызывают в большинстве случаев stack overflow с сопутствующим падением сервера. Теперь такого случаться не должно.