### PR TITLE
Fix: diagonal movement no longer breaks ventcrawling

### DIFF
--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -30,7 +30,8 @@
 /obj/machinery/atmospherics/relaymove(mob/living/user, direction)
 	if(user.loc != src || !(direction & initialize_directions)) //can't go in a way we aren't connecting to
 		return
-	ventcrawl_to(user,findConnecting(direction),direction)
+	direction &= ~(direction & ~initialize_directions)
+	ventcrawl_to(user,findConnecting(direction), direction)
 
 /obj/machinery/atmospherics/proc/ventcrawl_to(var/mob/living/user, var/obj/machinery/atmospherics/target_move, var/direction)
 	if(target_move)


### PR DESCRIPTION
Попытка переместиться диагонально во время нахождения в вентиляции больше не выкидывает из труб