### PR TITLE
Ядерные коды предателям в аплинк

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -170,6 +170,11 @@
 	item_cost = 30
 	path = /obj/item/device/radio/intercept
 	desc = "A radio that can intercept secure radio channels. Doesn't fit in pockets."
+/datum/uplink_item/item/tools/nukecode
+	name = "Self-destructing system authorization code"
+	item_cost = 90
+	path = /obj/item/paper/nukecodes
+	desc = "A truly suicidal mission"
 
 /datum/uplink_item/item/tools/ttv
 	name = "Binary Gas Bomb"

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -175,6 +175,7 @@
 	item_cost = 90
 	path = /obj/item/paper/nukecodes
 	desc = "A truly suicidal mission"
+	antag_roles = list(MODE_TRAITOR)
 
 /datum/uplink_item/item/tools/ttv
 	name = "Binary Gas Bomb"

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -504,7 +504,7 @@ var/bomb_set
 	var/announced = 0
 	var/time_to_explosion = 0
 	var/self_destruct_cutoff = 60 //Seconds
-	timeleft = 300 
+	timeleft = 300
 	minTime = 300
 	maxTime = 900
 
@@ -605,3 +605,12 @@ var/bomb_set
 				continue
 			T.icon_state = target_icon_state
 		last_turf_state = target_icon_state
+
+
+/obj/item/paper/nukecodes
+	name = "paper"
+
+/obj/item/paper/nukecodes/Initialize()
+	. = ..()
+	var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in SSmachines.machinery
+	info = "<tt><center><large><b>[nuke.r_code]<large><br><i>Good luck, Agent</b>"


### PR DESCRIPTION
Описание
Теперь у предателей в аплинке есть бумага с кодами от ядерного терминала. Стоит 90 ТК (самый дорогой предмет), но несмотря на высокую цену, активировать систему самоуничтожения всё также очень сложно
Это должно разнообразить геймплей на ролях, возможно откроет возможности кооперации предателей
А самое главное - игроки наконец-то начнут ценить ядерный диск, потому что вне мерков он не важнее банки Space Up

Приму критику и предложение для изменения
Основные изменения

* У предателей добавлена бумажка с кодами от системы самоуничтожения в аплинке

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
rscadd: Traitors now have a paper with the self-destruction codes in their uplink
/:cl:
