### PR TITLE
bugfix: fixed AI machinery explosion calculations and fixed the alias console command

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -136,14 +136,14 @@
 			var/obj/machinery/power/apc/A = N
 			var/obj/item/cell/cell = A.get_cell()
 			if(cell && cell.charge)
-				explosion_intensity = 4 + round((cell.charge / CELLRATE) / 100000)
+				explosion_intensity = 2 + round(((cell.charge / CELLRATE) / 100000) / 5)
 			else
 				to_chat(user, "<span class='notice'>ERROR: APC Malfunction - Cell depleted or removed. Unable to overload.</span>")
 				return
 		else if (istype(N, /obj/machinery/power/smes/buildable)) // SMES. These explode in a very very very big boom. Similar to magnetic containment failure when messing with coils.
 			var/obj/machinery/power/smes/buildable/S = N
 			if(S.charge && S.RCon)
-				explosion_intensity = 4 + round((S.charge / CELLRATE) / 100000)
+				explosion_intensity = round(((S.charge / CELLRATE) / 100000) / 200)
 			else
 				// Different error texts
 				if(!S.charge)

--- a/code/modules/modular_computers/terminal/terminal_commands.dm
+++ b/code/modules/modular_computers/terminal/terminal_commands.dm
@@ -574,6 +574,12 @@ INF*/
 			var/code = F.stored_data
 			if(!findtext(code, ";"))
 				return "<font color='#ff0000'>[name]: compile error, lack this ';'.</font>"
+			if(findtext(code, inp_file_name) || findtext(code, "alias"))
+				terminal.computer.get_component(PART_HDD).damage += 30
+				return "<font color='#ff0000'> compile error, possible recursion detected.</font>"
+			if(length(code) > 500)
+				terminal.computer.get_component(PART_HDD).damage += 10
+				return "<font color='#ff0000'> compile error, too much commands.</font>"
 
 			var/regex/RegexHTML = new("<\[^<>]*>", "g")
 			var/regex/RegexFileHTML = new("\\\[\[^\\\[\\\]]*\\\]", "g")


### PR DESCRIPTION
# Описание

Немного подправил расчеты для взрыва машинерии у абилки малфа, а также урезал команду alias в командной строке, чтобы она не вызывала лаги сервера

## Changelog

:cl:
bugfix: исправлен расчет для взрыва машинерии у малфа, а также исправлена команда 'alias' в командной строке
/:cl:
