### PR TITLE
Даём арсеналу Сьерры новый ПП

### DIFF
--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -7422,6 +7422,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/guncabinet/sierra_armory/smg,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/sierra/armory)
 "amU" = (

--- a/maps/sierra/structures/closets/armory.dm
+++ b/maps/sierra/structures/closets/armory.dm
@@ -5,8 +5,9 @@
 	name = "submachine gun guncabinet"
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/smg/WillContain()
-	return list(/obj/item/gun/projectile/automatic/nt41 = 2,
-				/obj/item/ammo_magazine/n10mm = 6)
+	return list(/obj/item/gun/projectile/automatic/sec_smg = 2,
+				/obj/item/ammo_magazine/smg_top/rubber = 4,
+				/obj/item/ammo_magazine/smg_top = 4)
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/shotgun
 	name = "shotgun guncabinet"


### PR DESCRIPTION
# Описание

Когда-то, давным-давно, кодеры Инфинити решили заменить ПП НТ41, ибо тот, ввиду своего калибра, рвал и метал, что кодерам не нравилось. Но к сожалению, всё умерло, и теперь у арсенала корабля есть пустое место. Это не радует глаз, поэтому было решено вернуть ПП, но менее жопоразрывной, чем ранее. Поэтому теперь, в шкафах smg лежат не НТ41, а WT-550 под 9мм патрон, способные пуляться как резиной, так и металлом.

## Основные изменения

1) Содержимое шкафов submachine gun guncabinet сменено с 6 магазинов для НТ41 и двух НТ41, на 8 магазинов для WT-550 суммарно, 2 нелетальных и 2 летальных магазина на каждый WT-550, которых также 2.
2) В арсенал наконец вернулся шкаф с ПП, заполнив пустое место у стенки.

:cl:
rscadd: В арсенал Сьерры возвращён шкаф для ПП. В самом же шкафу теперь лежат WT-550.
/:cl:
