### PR TITLE
AI added to traitor blacklist_jobs

### DIFF
--- a/maps/sierra/sierra_antagonism.dm
+++ b/maps/sierra/sierra_antagonism.dm
@@ -19,7 +19,7 @@
 	protected_jobs = list(/datum/job/iaa)
 
 /datum/antagonist/traitor
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/submap)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
 	protected_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/iaa, /datum/job/submap/merchant, /datum/job/submap/merchant_trainee)
 
 /datum/antagonist/ert/equip(var/mob/living/carbon/human/player)

--- a/maps/sierra/sierra_antagonism.dm
+++ b/maps/sierra/sierra_antagonism.dm
@@ -19,7 +19,7 @@
 	protected_jobs = list(/datum/job/iaa)
 
 /datum/antagonist/traitor
-	blacklisted_jobs = list(/datum/job/submap)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/submap)
 	protected_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/iaa, /datum/job/submap/merchant, /datum/job/submap/merchant_trainee)
 
 /datum/antagonist/ert/equip(var/mob/living/carbon/human/player)


### PR DESCRIPTION
# Описание

* Обрезал ИИ и киборгам возможность быть тритором

## Основные изменения

* Обрезал ИИ и киборгам возможность быть тритором

## Changelog

:cl:
tweak: Предатель: ИИ и киборгам убраны из списка возможных ролей для бытия предателем
/:cl:
