### PR TITLE
Добавление нового щита в арсенал

### DIFF
--- a/maps/sierra/datums/supplypacks/security.dm
+++ b/maps/sierra/datums/supplypacks/security.dm
@@ -112,6 +112,14 @@
 	access = access_heads
 	security_level = SUPPLY_SECURITY_ELEVATED
 
+/decl/hierarchy/supply_pack/security/ballistic_shields
+	name = "Combat Shields"
+	contains = list(/obj/item/shield/riot/metal = 4)
+	cost = 80
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper combat shields crate"
+	access = access_security
+
 /*
  * OVERRIDES
  * =========

--- a/maps/sierra/datums/supplypacks/security.dm
+++ b/maps/sierra/datums/supplypacks/security.dm
@@ -120,6 +120,14 @@
 	containername = "\improper combat shields crate"
 	access = access_security
 
+/decl/hierarchy/supply_pack/security/riot_shields
+	name = "Riot Shields"
+	contains = list(/obj/item/shield/riot = 3)
+	cost = 80
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper riot shields crate"
+	access = access_security
+
 /*
  * OVERRIDES
  * =========

--- a/maps/sierra/datums/supplypacks/security.dm
+++ b/maps/sierra/datums/supplypacks/security.dm
@@ -114,7 +114,7 @@
 
 /decl/hierarchy/supply_pack/security/ballistic_shields
 	name = "Combat Shields"
-	contains = list(/obj/item/shield/riot/metal = 4)
+	contains = list(/obj/item/shield/riot/metal = 3)
 	cost = 80
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper combat shields crate"

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -9367,6 +9367,9 @@
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
+/obj/item/shield/riot/metal,
+/obj/item/shield/riot/metal,
+/obj/item/shield/riot/metal,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/sierra/armory)
 "apQ" = (

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -9367,9 +9367,6 @@
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
-/obj/item/shield/riot/metal,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/sierra/armory)
 "apQ" = (


### PR DESCRIPTION
# Описание

В арсенал Сьерры вложены 3 боевых щита, сопоставимых количественно бронекостюмам от пуль. Такое решение было вызвано тем, что данные щиты хочется видеть где-либо кроме патрульника ЦПСС, где их никто и никогда не берёт, даже если там кто-то есть, и даже если там кто-то решил с двух ног и в боевых ИКСах вломиться на Сьерру. Если же данное решение категорически не устраивает тех, кто отвечает за баланс -- не вопрос, есть иной вариант -- я добавлю эти щиты в заказы карго. Критикуйте-предлагайте-оспаривайте.

:cl:
rscadd: В арсенал Сьерры вложены три щита от пуль и лазеров.
/:cl:
