### PR TITLE
Фикс голых парамедиков

### DIFF
--- a/maps/sierra/job/outfits.dm
+++ b/maps/sierra/job/outfits.dm
@@ -266,7 +266,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 
 /decl/hierarchy/outfit/job/sierra/crew/medical/doctor/paramedic
 	name = OUTFIT_JOB_NAME("Paramedic - Sierra")
-	uniform = /obj/item/clothing/under/rank/medical/paramedic
+	uniform = /obj/item/clothing/under/rank/medical
 	suit = /obj/item/clothing/suit/storage/toggle/fr_jacket
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_hand = /obj/item/storage/firstaid/adv


### PR DESCRIPTION
# Описание

Парамедикам давались short sleeve medical outfit. Проблема в том, что у этих штук нет спрайта, и какой он должен быть - полнейшая загадка. Поэтому было решено выдавать парамедам простые комбинезоны врачей.

:cl:
bugfix: Стоковая одежда парамедиков сменена на обычный докторский комбинезон без сломанных спрайтов.
/:cl:
