### PR TITLE
tweak: disable ability to spawn as VOX on Liberia

### DIFF
--- a/maps/away_inf/liberia/liberia_jobs.dm
+++ b/maps/away_inf/liberia/liberia_jobs.dm
@@ -34,7 +34,7 @@
 	create_record = 0
 	outfit_type = /decl/hierarchy/outfit/job/liberia/merchant/leader
 	whitelisted_species = null
-	blacklisted_species = list(SPECIES_ALIEN, SPECIES_GOLEM, SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_MONARCH_WORKER, SPECIES_MONARCH_QUEEN, SPECIES_XENO)
+	blacklisted_species = list(SPECIES_VOX, SPECIES_ALIEN, SPECIES_GOLEM, SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_MONARCH_WORKER, SPECIES_MONARCH_QUEEN, SPECIES_XENO)
 	allowed_branches = list(
 		/datum/mil_branch/civilian
 	)


### PR DESCRIPTION
Воксы не смогут появляться на Либерии