### PR TITLE
Возврат телепорта V 2.0

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -559,6 +559,7 @@
 	outputs = list()
 	activators = list("open rift" = IC_PINTYPE_PULSE_IN)
 	action_flags = IC_ACTION_LONG_RANGE
+    spawn_flags = IC_SPAWN_RESEARCH
 
 	origin_tech = list(TECH_MAGNET = 1, TECH_BLUESPACE = 3)
 	matter = list(MATERIAL_STEEL = 10000, MATERIAL_SILVER = 2000, MATERIAL_GOLD = 200)


### PR DESCRIPTION
# Описание
Приветствую, читатель.
Я считаю неправильным то, что такой интересный и полезный модуль как рифт генератор был выпилен из печати.

На оффах его удалили из-за некого "Телегрифа", но я считаю это очень абсурдной причиной, для этого есть баны данных индивидумов.

Телепорт дает много интересных возможностей для интегральщиков, это один из немногих полезных и интересных НЕ боевых модулей.

Предлогаю взглянуть на следующие строки:

matter = list(MATERIAL_STEEL = 10000, MATERIAL_SILVER = 2000, MATERIAL_GOLD = 200)

complexity = 100

Данный модуль требует очень много стали, а так же серебро и золото, что исключает так называемый телегриф, его без карго или шахтеров не сделать абсолютно никак.

Второе это сложность, что не позволит делать карманные сборки, вполне балансный модуль, к тому же имеющий К/д в 12 секунд, телепортирующий рандомно без подключения к материнскому телепорту.
    При подключении к телепорту интегралка просто будет открывать портал туда, куда указал стационарный телепорт.

Я считаю, что обрезать игровые возможности из-за недалеких игроков на оффбее - идиотизм.
К тому же, данный модуль есть на небуле, но там вы его почему-то не вырезали.

## Основные изменения

* Разрешена печать в принтере интегральных цепей

Надеюсь на вашу обьективность.