### PR TITLE
Second sofa crisis

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -73,6 +73,9 @@
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
 
+/obj/structure/bed/chair/padded/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, padding_material)
+
 /obj/structure/bed/chair/padded/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_RED_CLOTH)
 
@@ -113,6 +116,9 @@
 	icon_state = "comfychair_preview"
 	base_icon = "comfychair"
 
+/obj/structure/bed/chair/comfy/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, padding_material)
+
 /obj/structure/bed/chair/comfy/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
 
@@ -150,6 +156,9 @@
 	desc = "It's a rounded chair. It looks comfy."
 	icon_state = "roundedchair_preview"
 	base_icon = "roundedchair"
+
+/obj/structure/bed/chair/rounded/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, padding_material)
 
 /obj/structure/bed/chair/rounded/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
@@ -196,7 +205,7 @@
 	overlays |= I
 
 /obj/structure/bed/chair/comfy/captain/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
-	..(newloc,MATERIAL_STEEL,MATERIAL_BLUE_CLOTH)
+	..(newloc, MATERIAL_STEEL, MATERIAL_BLUE_CLOTH)
 
 /obj/structure/bed/chair/armchair
 	name = "armchair"
@@ -204,6 +213,9 @@
 	icon_state = "armchair_preview"
 	base_icon = "armchair"
 	buckle_movable = FALSE
+
+/obj/structure/bed/chair/armchair/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, padding_material)
 
 /obj/structure/bed/chair/armchair/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
@@ -281,6 +293,10 @@
 			victim.apply_damage(10, BRUTE, def_zone)
 		occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")
 
+
+/obj/structure/bed/chair/office/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, padding_material)
+
 /obj/structure/bed/chair/office/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
 
@@ -319,6 +335,9 @@
 	desc = "It's an office chair. It looks comfy."
 	icon_state = "comfyofficechair_preview"
 	base_icon = "comfyofficechair"
+
+/obj/structure/bed/chair/office/comfy/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, newmaterial, padding_material)
 
 /obj/structure/bed/chair/office/comfy/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
@@ -377,17 +396,20 @@
 			I.color = material.icon_colour
 		overlays |= I
 
+/obj/structure/bed/chair/shuttle/hard/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
+	..(newloc, MATERIAL_STEEL, padding_material)
+
 /obj/structure/bed/chair/shuttle/blue/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
-	..(newloc,MATERIAL_STEEL,MATERIAL_BLUE_CLOTH)
+	..(newloc, MATERIAL_STEEL, MATERIAL_BLUE_CLOTH)
 
 /obj/structure/bed/chair/shuttle/black/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
-	..(newloc,MATERIAL_STEEL,MATERIAL_BLACK_CLOTH)
+	..(newloc, MATERIAL_STEEL ,MATERIAL_BLACK_CLOTH)
 
 /obj/structure/bed/chair/shuttle/white/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
-	..(newloc,MATERIAL_STEEL,MATERIAL_CLOTH)
+	..(newloc, MATERIAL_STEEL, MATERIAL_CLOTH)
 
 /obj/structure/bed/chair/shuttle/red/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
-	..(newloc, MATERIAL_STEEL, MATERIAL_CARPET)
+	..(newloc, MATERIAL_STEEL, MATERIAL_RED_CLOTH)
 
 /obj/structure/bed/chair/shuttle/green/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, MATERIAL_STEEL, MATERIAL_GREEN_CLOTH)

--- a/code/game/objects/structures/stool_bed_chair_nest/sofa.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/sofa.dm
@@ -79,6 +79,10 @@
 	set_dir(turn(dir, 90))
 	update_icon()
 
+/obj/structure/bed/sofa/m/hard/New(newloc, newmaterial = MATERIAL_WOOD)
+	..(newloc, newmaterial, padding_material)
+	anchored = FALSE
+
 /obj/structure/bed/sofa/m/red/New(newloc, newmaterial = MATERIAL_WOOD)
 	..(newloc, newmaterial, MATERIAL_RED_CLOTH)
 
@@ -118,6 +122,10 @@
 	icon_state = "sofa_r_preview"
 	base_icon = "sofa_r"
 
+/obj/structure/bed/sofa/r/hard/New(newloc, newmaterial = MATERIAL_WOOD)
+	..(newloc, newmaterial, padding_material)
+	anchored = FALSE
+
 /obj/structure/bed/sofa/r/red/New(newloc, newmaterial = MATERIAL_WOOD)
 	..(newloc, newmaterial, MATERIAL_RED_CLOTH)
 
@@ -156,6 +164,10 @@
 	desc = "A wide and comfy sofa - no one assistant was ate by it due production! It's made of wood and covered with synthetic leather."
 	icon_state = "sofa_l_preview"
 	base_icon = "sofa_l"
+
+/obj/structure/bed/sofa/l/hard/New(newloc, newmaterial = MATERIAL_WOOD)
+	..(newloc, newmaterial, padding_material)
+	anchored = FALSE
 
 /obj/structure/bed/sofa/l/red/New(newloc, newmaterial = MATERIAL_WOOD)
 	..(newloc, newmaterial, MATERIAL_RED_CLOTH)

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -60,15 +60,13 @@
 	. = ..()
 	if(reinforce_material)	//recipies below don't support composite materials
 		return
-	. += new/datum/stack_recipe_list("office chairs",list(
-		new/datum/stack_recipe/furniture/chair/office/dark(src),
-		new/datum/stack_recipe/furniture/chair/office/light(src)
-		))
-	. += new/datum/stack_recipe_list("comfy office chairs", create_recipe_list(/datum/stack_recipe/furniture/chair/office/comfy))
-	. += new/datum/stack_recipe_list("comfy chairs", create_recipe_list(/datum/stack_recipe/furniture/chair/comfy))
-	. += new/datum/stack_recipe_list("rounded chairs", create_recipe_list(/datum/stack_recipe/furniture/chair/rounded))
-	. += new/datum/stack_recipe_list("armchairs", create_recipe_list(/datum/stack_recipe/furniture/chair/arm))
-	. += new/datum/stack_recipe_list("padded [display_name] chairs", create_recipe_list(/datum/stack_recipe/furniture/chair/padded))
+	. += new/datum/stack_recipe/furniture/sofa/l(src)
+	. += new/datum/stack_recipe/furniture/chair/office(src)
+	. += new/datum/stack_recipe/furniture/chair/office/comfy(src)
+	. += new/datum/stack_recipe/furniture/chair/comfy(src)
+	. += new/datum/stack_recipe/furniture/chair/rounded(src)
+	. += new/datum/stack_recipe/furniture/chair/arm(src)
+	. += new/datum/stack_recipe/furniture/chair/padded(src)
 	. += new/datum/stack_recipe/key(src)
 	. += new/datum/stack_recipe/furniture/table_frame(src)
 	. += new/datum/stack_recipe/furniture/rack(src)
@@ -127,6 +125,9 @@
 	. += new/datum/stack_recipe/sandals(src)
 	. += new/datum/stack_recipe/tile/wood(src)
 	. += create_recipe_list(/datum/stack_recipe/furniture/chair/wood)
+	. += new/datum/stack_recipe/furniture/sofa/m(src)
+	. += new/datum/stack_recipe/furniture/sofa/r(src)
+	. += new/datum/stack_recipe/furniture/sofa/l(src)
 	. += new/datum/stack_recipe/crossbowframe(src)
 	. += new/datum/stack_recipe/furniture/coffin/wooden(src)
 	. += new/datum/stack_recipe/beehive_assembly(src)
@@ -137,9 +138,6 @@
 	. += new/datum/stack_recipe/stick(src)
 	. += new/datum/stack_recipe/noticeboard(src)
 	. += new/datum/stack_recipe/furniture/table_frame(src)
-	. += new/datum/stack_recipe_list("middle sofa", create_recipe_list(/datum/stack_recipe/furniture/sofa/m))
-	. += new/datum/stack_recipe_list("left sofa", create_recipe_list(/datum/stack_recipe/furniture/sofa/l))
-	. += new/datum/stack_recipe_list("right sofa", create_recipe_list(/datum/stack_recipe/furniture/sofa/r))
 
 /material/wood/mahogany/generate_recipes(var/reinforce_material)
 	. = ..()

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -17,117 +17,32 @@
 
 /datum/stack_recipe/furniture/chair/padded
 	req_amount = 2
-
-#define PADDED_CHAIR(color) /datum/stack_recipe/furniture/chair/padded/##color{\
-	result_type = /obj/structure/bed/chair/padded/##color;\
-	modifiers = list("padded", #color)\
-	}
-PADDED_CHAIR(beige)
-PADDED_CHAIR(black)
-PADDED_CHAIR(brown)
-PADDED_CHAIR(lime)
-PADDED_CHAIR(teal)
-PADDED_CHAIR(red)
-PADDED_CHAIR(purple)
-PADDED_CHAIR(green)
-PADDED_CHAIR(yellow)
-#undef PADDED_CHAIR
+	result_type = /obj/structure/bed/chair/padded/hard
 
 /datum/stack_recipe/furniture/chair/office
 	title = "office chair"
+	result_type = /obj/structure/bed/chair/office/hard
 	req_amount = 5
 
-/datum/stack_recipe/furniture/chair/office/display_name()
-	return modifiers ? jointext(modifiers + title, " ") : title // Bypass material
-
-/datum/stack_recipe/furniture/chair/office/light
-	result_type = /obj/structure/bed/chair/office/light
-	modifiers = list("light")
-
-/datum/stack_recipe/furniture/chair/office/dark
-	result_type = /obj/structure/bed/chair/office/dark
-	modifiers = list("dark")
-
 /datum/stack_recipe/furniture/chair/office/comfy
+	result_type = /obj/structure/bed/chair/office/comfy/hard
 	req_amount = 7
-
-#define COMFY_OFFICE_CHAIR(color) /datum/stack_recipe/furniture/chair/office/comfy/##color{\
-	result_type = /obj/structure/bed/chair/office/comfy/##color;\
-	modifiers = list(#color, "comfy")\
-	}
-COMFY_OFFICE_CHAIR(beige)
-COMFY_OFFICE_CHAIR(black)
-COMFY_OFFICE_CHAIR(brown)
-COMFY_OFFICE_CHAIR(lime)
-COMFY_OFFICE_CHAIR(teal)
-COMFY_OFFICE_CHAIR(red)
-COMFY_OFFICE_CHAIR(purple)
-COMFY_OFFICE_CHAIR(green)
-COMFY_OFFICE_CHAIR(yellow)
-#undef COMFY_OFFICE_CHAIR
 
 /datum/stack_recipe/furniture/chair/comfy
 	title = "comfy chair"
+	result_type = /obj/structure/bed/chair/office/comfy/hard
 	req_amount = 3
-
-#define COMFY_CHAIR(color) /datum/stack_recipe/furniture/chair/comfy/##color{\
-	result_type = /obj/structure/bed/chair/comfy/##color;\
-	modifiers = list(#color)\
-	}
-COMFY_CHAIR(beige)
-COMFY_CHAIR(black)
-COMFY_CHAIR(brown)
-COMFY_CHAIR(lime)
-COMFY_CHAIR(teal)
-COMFY_CHAIR(red)
-COMFY_CHAIR(purple)
-COMFY_CHAIR(green)
-COMFY_CHAIR(yellow)
-#undef COMFY_CHAIR
 
 /datum/stack_recipe/furniture/chair/rounded
 	title = "rounded chair"
+	result_type = /obj/structure/bed/chair/rounded/hard
 	req_amount = 3
-
-#define ROUNDED_CHAIR(color) /datum/stack_recipe/furniture/chair/rounded/##color{\
-	result_type = /obj/structure/bed/chair/rounded/##color;\
-	modifiers = list(#color, "rounded")\
-	}
-ROUNDED_CHAIR(beige)
-ROUNDED_CHAIR(black)
-ROUNDED_CHAIR(brown)
-ROUNDED_CHAIR(blue)
-ROUNDED_CHAIR(lime)
-ROUNDED_CHAIR(teal)
-ROUNDED_CHAIR(red)
-ROUNDED_CHAIR(purple)
-ROUNDED_CHAIR(green)
-ROUNDED_CHAIR(yellow)
-ROUNDED_CHAIR(light)
-#undef ROUNDED_CHAIR
 
 /datum/stack_recipe/furniture/chair/arm
 	title = "armchair"
+	result_type = /obj/structure/bed/chair/armchair/hard
 	req_amount = 4
 
-#define ARMCHAIR(color) /datum/stack_recipe/furniture/chair/arm/##color{\
-	result_type = /obj/structure/bed/chair/armchair/##color;\
-	modifiers = list(#color)\
-	}
-ARMCHAIR(beige)
-ARMCHAIR(black)
-ARMCHAIR(brown)
-ARMCHAIR(blue)
-ARMCHAIR(lime)
-ARMCHAIR(teal)
-ARMCHAIR(red)
-ARMCHAIR(purple)
-ARMCHAIR(green)
-ARMCHAIR(yellow)
-ARMCHAIR(light)
-#undef ARMCHAIR
-
-//SOFA
 /datum/stack_recipe/furniture/sofa
 	title = "sofa"
 	result_type = /obj/structure/bed/sofa
@@ -139,68 +54,19 @@ ARMCHAIR(light)
 
 /datum/stack_recipe/furniture/sofa/m
 	title = "middle sofa"
+	result_type = /obj/structure/bed/sofa/m/hard
 	req_amount = 3
-
-#define MIDDLE_SOFA(color) /datum/stack_recipe/furniture/sofa/m/##color{\
-	result_type = /obj/structure/bed/sofa/m/##color;\
-	modifiers = list(#color, "middle")\
-	}
-MIDDLE_SOFA(beige)
-MIDDLE_SOFA(black)
-MIDDLE_SOFA(brown)
-MIDDLE_SOFA(blue)
-MIDDLE_SOFA(lime)
-MIDDLE_SOFA(teal)
-MIDDLE_SOFA(red)
-MIDDLE_SOFA(purple)
-MIDDLE_SOFA(green)
-MIDDLE_SOFA(yellow)
-MIDDLE_SOFA(light)
-#undef MIDDLE_SOFA
 
 /datum/stack_recipe/furniture/sofa/l
 	title = "left sofa"
+	result_type = /obj/structure/bed/sofa/l/hard
 	req_amount = 3
-
-#define LEFT_SOFA(color) /datum/stack_recipe/furniture/sofa/l/##color{\
-	result_type = /obj/structure/bed/sofa/l/##color;\
-	modifiers = list(#color, "left")\
-	}
-LEFT_SOFA(beige)
-LEFT_SOFA(black)
-LEFT_SOFA(brown)
-LEFT_SOFA(blue)
-LEFT_SOFA(lime)
-LEFT_SOFA(teal)
-LEFT_SOFA(red)
-LEFT_SOFA(purple)
-LEFT_SOFA(green)
-LEFT_SOFA(yellow)
-LEFT_SOFA(light)
-#undef LEFT_SOFA
 
 /datum/stack_recipe/furniture/sofa/r
 	title = "right sofa"
+	result_type = /obj/structure/bed/sofa/r/hard
 	req_amount = 3
 
-#define RIGHT_SOFA(color) /datum/stack_recipe/furniture/sofa/r/##color{\
-	result_type = /obj/structure/bed/sofa/r/##color;\
-	modifiers = list(#color, "right")\
-	}
-RIGHT_SOFA(beige)
-RIGHT_SOFA(black)
-RIGHT_SOFA(brown)
-RIGHT_SOFA(blue)
-RIGHT_SOFA(lime)
-RIGHT_SOFA(teal)
-RIGHT_SOFA(red)
-RIGHT_SOFA(purple)
-RIGHT_SOFA(green)
-RIGHT_SOFA(yellow)
-RIGHT_SOFA(light)
-#undef RIGHT_SOFA
-
-//END SOFA
 /datum/stack_recipe/furniture/chair/wood
 	req_amount = 3
 

--- a/maps/away_inf/liberia/liberia.dmm
+++ b/maps/away_inf/liberia/liberia.dmm
@@ -3562,8 +3562,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/structure/bed/sofa/l/black{
-	},
+/obj/structure/bed/sofa/l/black,
 /turf/simulated/floor/carpet,
 /area/liberia/bar)
 "fQ" = (
@@ -3574,7 +3573,7 @@
 	pixel_y = 24
 	},
 /obj/structure/bed/sofa/m/black{
-	dir = 10;
+	dir = 10
 	},
 /turf/simulated/floor/carpet,
 /area/liberia/bar)
@@ -3755,7 +3754,7 @@
 /area/liberia/officeroom)
 "gf" = (
 /obj/structure/bed/sofa/r/black{
-	dir = 4;
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -3768,7 +3767,7 @@
 /area/liberia/bar)
 "gh" = (
 /obj/structure/bed/sofa/r/black{
-	dir = 8;
+	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -3862,7 +3861,7 @@
 	dir = 10
 	},
 /obj/structure/bed/sofa/l/black{
-	dir = 4;
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/liberia/bar)
@@ -5553,7 +5552,7 @@
 	pixel_y = 24
 	},
 /obj/structure/bed/sofa/m/black{
-	dir = 6;
+	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/liberia/library)
@@ -5564,9 +5563,7 @@
 /obj/machinery/alarm/merchant{
 	pixel_y = 24
 	},
-/obj/structure/bed/sofa/r/black{
-	dir = 6;
-	},
+/obj/structure/bed/sofa/r/black,
 /turf/simulated/floor/carpet,
 /area/liberia/library)
 "jM" = (
@@ -5725,7 +5722,7 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/effect/submap_landmark/spawnpoint/liberia/doctor,
 /obj/structure/bed/sofa/l/black{
-	dir = 4;
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/liberia/library)


### PR DESCRIPTION
# Описание

* Всё это затеяно, чтобы нельзя было построить кресло из дерева и при разборе получить бесплатную ткань

## Основные изменения
* Теперь мебель при постройке не имеют обивку, это касается: 
* Диванов
![image](https://user-images.githubusercontent.com/87154286/156935852-cea3ee72-41d1-426c-823c-fbb329c3233e.png)

* Кресел
![image](https://user-images.githubusercontent.com/87154286/156935859-b0ae6e96-d5bf-41c0-be5f-c40180b9c603.png)

* Офисных стульев
![image](https://user-images.githubusercontent.com/87154286/156935887-174ed901-a924-4e16-9f39-015c0b5c365c.png)

* Закруглённых кресел
![image](https://user-images.githubusercontent.com/87154286/156935897-cdece741-e421-447b-b7d5-67fa29a25dc3.png)

* Барный и обычных стульев
![image](https://user-images.githubusercontent.com/87154286/156935920-88fe8fa5-9535-41d3-b8cb-9c7bfafa6726.png)

* Кроватей
![image](https://user-images.githubusercontent.com/87154286/156935938-ae6b772a-1b3c-44e9-bbb6-e313b2a04d14.png)

* Напоминаю, что все материалы для обивки доступны для заказа в карго.

:cl:
fix:
Поправлен dir дивана на либерии
feat:
Вся мебель из вкладки furniture теперь строится без обивки, для предотвращения магического появления ткани из воздуха.
Визуально облегчена вкладка строительства.
tweak:
Попутная оптимизация кода
/:cl: