### PR TITLE
fix of ununique seed uid

### DIFF
--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -168,7 +168,7 @@
 		seed.dropInto(loc)
 
 		if(seed.seed.name == "new line" || isnull(SSplants.seeds[seed.seed.name]))
-			seed.seed.uid = SSplants.seeds.len + 1
+			seed.seed.uid = sequential_id(/datum/seed/)
 			seed.seed.name = "[seed.seed.uid]"
 			SSplants.seeds[seed.seed.name] = seed.seed
 


### PR DESCRIPTION
# Описание

Доработка фикса не уникальных имен мутированных и модифицированных семян. В прошлом фиксе не поправили именование семян при выгрузке из  bioballistic delivery system

## Основные изменения

* при выгрузке из bioballistic delivery system семенам даются уникальные имена


## Changelog

:cl:
bugfix: поправлено "запутывание" типа семян при использовании устройства для их модификации
/:cl:
