### PR TITLE
Смена ПП в арсенале брига

### DIFF
--- a/maps/sierra/structures/closets/armory.dm
+++ b/maps/sierra/structures/closets/armory.dm
@@ -5,9 +5,8 @@
 	name = "submachine gun guncabinet"
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/smg/WillContain()
-	return list(/obj/item/gun/projectile/automatic/sec_smg = 2,
-				/obj/item/ammo_magazine/smg_top/rubber = 4,
-				/obj/item/ammo_magazine/smg_top = 4)
+	return list(/obj/item/gun/projectile/automatic/nt41 = 2,
+				/obj/item/ammo_magazine/n10mm = 6)
 
 /obj/structure/closet/secure_closet/guncabinet/sierra_armory/shotgun
 	name = "shotgun guncabinet"


### PR DESCRIPTION
# Описание

Как показал опыт игры мейнеров СБ(DenGoHa, TheAtlasPlay, The_Hero13) и их отзывы, а также мой опыт игры на СБ с моим же нововведением, WT-550 не работает в тех условиях, в которых автоматическое оружие обычно используется, то бишь в реалиях Сьерры, в баталии с тяжелобронированным засранцем или группой наёмников, ибо 9мм спокойно съедаются любой бронёй без особых последствий для обстреливаемого. А резиновые пули никто не использует для подавления толпы, так как для этого есть тазеры и гранаты с перцем/флешбенги. Поэтому было решено вернуть то, что было давно и долго - НТ41.

## Основные изменения

ВТ-550 выкинут. НТ41 возвращён в шкаф в количестве 2 штук и 6 магазинов.

:cl:
balance: ВТ-550 выкинуты из арсенала в космос ввиду их неэффективности. В арсенал возвращены НТ41.
/:cl:
