### PR TITLE
Фиксинг зоны у шторки кухни

### DIFF
--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -34584,7 +34584,7 @@
 	name = "Cafe Shutters"
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/cafe)
+/area/crew_quarters/galley)
 "egu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4


### PR DESCRIPTION
# Описание

Дал второй шторке кухни зону самой кухни а не кафе. Теперь для вскрытия шторок не надо как идиот бегать между АПЦ кухни и кафе. И также не надо страдать, если удалось включить свет на кухне, но не в кафе, от чего одна из шторок не работает.

:cl:
bugfix: У обеих шторок кухни теперь прописана зона кухни, что делает их зависимыми от АПЦ кухни, а не от АПЦ кухни и кафе.
/:cl:
