### PR TITLE
Баффаем скафандры

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -348,9 +348,9 @@
 	item_state = "secalt_helm"
 	light_overlay = "helmet_light_alt"
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, //INF WAS ARMOR_MELEE_VERY_HIGH
+		melee = ARMOR_MELEE_RESISTANT, 
 		bullet = ARMOR_BALLISTIC_PISTOL, //INF WAS ARMOR_BALLISTIC_SMALL
-		laser = ARMOR_LASER_SMALL,
+		laser = ARMOR_LASER_HANDGUNS,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR)
@@ -369,9 +369,9 @@
 		)
 //[/INF]
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, //INF WAS ARMOR_MELEE_VERY_HIGH
+		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_PISTOL, //INF WAS ARMOR_BALLISTIC_SMALL
-		laser = ARMOR_LASER_SMALL,
+		laser = ARMOR_LASER_HANDGUNS,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR)


### PR DESCRIPTION
# Описание

На один уровень повысил защиту охранных скафандров от мили урона и лазеров. Это было сделано ввиду того, что с 15 поинтами защиты от мили, в охранном, на минуточку, скафандре, тебе карпы спокойно откусывали жопу(и это при том, что инженеры в своём инженерном скафандре в ближнем бою с карпами ощущают себя просто супер), и ввиду того, что 25 поинтов защиты от лазеров это несерьёзно для скафандра охраны, которая в массе своей использует лазеры. Итого защита от мили и лазеров повышена до 30 и 40.

## Основные изменения

1. На один уровень бафнута защита от мили.
2. На один уровень бафнута защита от лазеров.

:cl:
balance: Защита охранных скафандров от ближнего боя и лазеров повышена.
/:cl:
