### PR TITLE
Feat: Add VentCrawl Ability for Maintenance Drones // Тех. дронам добавлена способность лезть в вентиляции

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -89,6 +89,8 @@ var/list/mob_hat_cache = list()
 		var/datum/robot_component/C = components[V]
 		C.max_damage = 10
 
+	verbs += /mob/living/proc/ventcrawl // probably its should be here, not sure..
+	
 	verbs -= /mob/living/silicon/robot/verb/Namepick
 	update_icon()
 

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -99,6 +99,9 @@ var/list/ventcrawl_machinery = list(
 /mob/living/carbon/alien/ventcrawl_carry()
 	return 1
 
+/mob/living/silicon/robot/drone/ventcrawl_carry() // by the default drones carrying items in invis hand slots.. like alarm monitor or smth..
+	return 1
+
 /mob/living/proc/handle_ventcrawl(var/atom/clicked_on)
 	if(!can_ventcrawl())
 		return


### PR DESCRIPTION
# Описание: Добавлена абилка тех. дрону чтобы он смог ползать в вентиляции. 

В вики оффициалов написано что абилка должна была быть, я делал предложку, но разрабы пропали и предложка сдулась. Пусть тогда будет у нас.

## Основные изменения

Изменено 2 файла: 

* drone.dm, где добавлена абилка;

* ventcrawl.dm, где указано, что дроны могут лезть в венту с вещами (это надо, у дронов в невидимых 4->n клешнях носятся инструменты вроде аларм монитора... и он не мог лезть в венту).

По факту ничего иного не трогалось, хотя на локалке возникли проблемы с ALT+M1 по венте, но видимо это из-за админ-инструментария, впринципе всё должно работать как у мышей. И нет я не профи в кодинге в целом, но на вид всё встало корректно, я попытался.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: added VentCrawl ability for maintenance drones
/:cl:
