### PR TITLE
Fix zippo.  

### DIFF
--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -165,6 +165,8 @@
 		O.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, "<span class='notice'>You refuel [src] from \the [O]</span>")
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
+	else if(lit && istype(O))
+		O.HandleObjectHeating(src, user, 700)
 
 /obj/item/flame/lighter/zippo/black
 	color = COLOR_DARK_GRAY


### PR DESCRIPTION
# Описание

Правка недочета,  что зиппо не может греть предметы как зажигалка. 

:cl:
bugfix: zippo can now heat stuff
/:cl:
