### PR TITLE
Added event listeners to zoom proc

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -757,6 +757,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	GLOB.dir_set_event.register(user, src, /obj/item/proc/unzoom)
 	GLOB.hands_swapped_event.register(user, src, /obj/item/proc/unzoom)
 	GLOB.item_unequipped_event.register(src, src, /obj/item/proc/zoom_drop)
+	GLOB.item_equipped_event.register(src, src, /obj/item/proc/zoom_drop)
 	GLOB.stat_set_event.register(user, src, /obj/item/proc/unzoom)
 
 /obj/item/proc/zoom_drop(var/obj/item/I, var/mob/user)
@@ -772,6 +773,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	GLOB.dir_set_event.unregister(user, src, /obj/item/proc/unzoom)
 	GLOB.hands_swapped_event.unregister(user, src, /obj/item/proc/unzoom)
 	GLOB.item_unequipped_event.unregister(src, src, /obj/item/proc/zoom_drop)
+	GLOB.item_equipped_event.unregister(src, src, /obj/item/proc/zoom_drop)
 
 	user = user == src ? loc : (user || loc)
 	if(!istype(user))


### PR DESCRIPTION
# Описание

Добавил дополнительный слушатель событий при использовании бинокля и других зумящих устройств.

:cl:
bugfix: added event listeners to zoom proc
/:cl:
