### PR TITLE
rogue_drone weapon variability

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
@@ -6,6 +6,27 @@
 	health = 50
 	maxHealth = 50
 	natural_weapon = /obj/item/natural_weapon/drone_slicer
+	possible_natural_weapon = list(/obj/item/natural_weapon/drone_slicer,
+									/obj/item/weldingtool,
+									/obj/item/screwdriver,
+									/obj/item/wrench,
+									/obj/item/crowbar,
+									/obj/item/wirecutters,
+									/obj/item/device/multitool,
+									/obj/item/device/lightreplacer,
+									/obj/item/extinguisher/mini,
+									/obj/item/device/plunger/robot,
+									/obj/item/reagent_containers/spray/cleaner/drone,
+									/obj/item/stack/material/cyborg/steel,
+									/obj/item/stack/material/rods/cyborg,
+									/obj/item/stack/tile/floor/cyborg,
+									/obj/item/stack/material/cyborg/glass,
+									/obj/item/stack/material/cyborg/glass/reinforced,
+									/obj/item/stack/tile/wood/cyborg,
+									/obj/item/stack/material/cyborg/wood,
+									/obj/item/stack/cable_coil/cyborg,
+									/obj/item/stack/material/cyborg/plastic
+									)
 	speak_emote = list("blares","buzzes","beeps")
 	faction = "silicon"
 	min_gas = null
@@ -17,6 +38,10 @@
 
 	ai_holder_type = /datum/ai_holder/simple_animal/rogue_drone
 	say_list_type = /datum/say_list/rogue_drone
+
+/mob/living/simple_animal/hostile/rogue_drone/get_natural_weapon()
+	natural_weapon = pick(possible_natural_weapon)
+	return ..()
 
 /mob/living/simple_animal/hostile/rogue_drone/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bad_drone.dm
@@ -39,7 +39,15 @@
 	ai_holder_type = /datum/ai_holder/simple_animal/rogue_drone
 	say_list_type = /datum/say_list/rogue_drone
 
+/mob/living/simple_animal/hostile/rogue_drone/death()
+	explosion(src.loc, 0, 0, 1, 3, 0)
+	. = ..()
+
+/mob/living/simple_animal/hostile/rogue_drone/canUnEquip(obj/item/I)
+	return FALSE
+
 /mob/living/simple_animal/hostile/rogue_drone/get_natural_weapon()
+	QDEL_NULL(natural_weapon)
 	natural_weapon = pick(possible_natural_weapon)
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -96,6 +96,7 @@
 
 	//LETTING SIMPLE ANIMALS ATTACK? WHAT COULD GO WRONG. Defaults to zero so Ian can still be cuddly
 	var/obj/item/natural_weapon/natural_weapon
+	var/list/possible_natural_weapon
 	var/friendly = "nuzzles"
 	var/environment_smash = 0
 	var/resistance		  = 0	// Damage reduction


### PR DESCRIPTION
# Описание

реализация следующего предложения:
![image](https://user-images.githubusercontent.com/80123534/165171159-cb54a399-2459-4bf2-abd2-1de15fd3ac0d.png)

Предметы для оружия взяты из стандартного набора инструментов дрона

## Основные изменения

* Добавлена вариативность используемого оружия сбойными дронами

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: Добавлена вариативность используемого оружия сбойными дронами
/:cl:
