### PR TITLE
bugfix: Mesons from loadout for KM and medhud for field medic

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -82,7 +82,7 @@
 /datum/gear/eyes/meson
 	display_name = "Meson Goggles"
 	path = /obj/item/clothing/glasses/meson
-	allowed_roles = list(/datum/job/chief_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist, /datum/job/rd)
+	allowed_roles = list(/datum/job/chief_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist, /datum/job/rd, /datum/job/qm)
 	cost = 3
 
 /datum/gear/eyes/meson/prescription

--- a/maps/sierra/loadout/loadout_eyes.dm
+++ b/maps/sierra/loadout/loadout_eyes.dm
@@ -5,10 +5,13 @@
 	allowed_roles = SECURITY_ROLES
 
 /datum/gear/eyes/medical
-	allowed_roles = MEDICAL_ROLES
+	allowed_roles = list(\
+	/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor,\
+	/datum/job/doctor_trainee, /datum/job/explorer_medic,\
+	/datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/explorer_medic)
 
 /datum/gear/eyes/meson
-	allowed_roles = list(/datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /datum/job/rd,/datum/job/senior_scientist, /datum/job/scientist, /datum/job/chief_engineer,/datum/job/engineer_trainee,/datum/job/exploration_leader, /datum/job/explorer, /datum/job/explorer_pilot,/datum/job/explorer_medic, /datum/job/explorer_engineer)
+	allowed_roles = list(/datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /datum/job/rd,/datum/job/senior_scientist, /datum/job/scientist, /datum/job/chief_engineer,/datum/job/engineer_trainee,/datum/job/exploration_leader, /datum/job/explorer, /datum/job/explorer_pilot,/datum/job/explorer_medic, /datum/job/explorer_engineer, /datum/job/qm)
 
 /datum/gear/eyes/material
 	allowed_roles = TECHNICAL_ROLES

--- a/maps/sierra/loadout/loadout_eyes.dm
+++ b/maps/sierra/loadout/loadout_eyes.dm
@@ -4,12 +4,9 @@
 /datum/gear/eyes/security
 	allowed_roles = SECURITY_ROLES
 
-/datum/gear/eyes/medical
-	allowed_roles = list(\
-	/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor,\
-	/datum/job/doctor_trainee, /datum/job/explorer_medic,\
-	/datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/explorer_medic)
-
+/datum/gear/eyes/medical/New()
+  allowed_roles = MEDICAL_ROLES + /datum/job/explorer_medic
+  ..()
 /datum/gear/eyes/meson
 	allowed_roles = list(/datum/job/senior_engineer, /datum/job/engineer, /datum/job/mining, /datum/job/scientist_assistant, /datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /datum/job/rd,/datum/job/senior_scientist, /datum/job/scientist, /datum/job/chief_engineer,/datum/job/engineer_trainee,/datum/job/exploration_leader, /datum/job/explorer, /datum/job/explorer_pilot,/datum/job/explorer_medic, /datum/job/explorer_engineer, /datum/job/qm)
 

--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -2,7 +2,10 @@
 	allowed_roles = TECHNICAL_ROLES
 
 /datum/gear/augment/integrated_health_hud
-	allowed_roles = MEDICAL_ROLES
+	allowed_roles = list(\
+	/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor,\
+	/datum/job/doctor_trainee, /datum/job/explorer_medic,\
+	/datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/explorer_medic)
 
 /datum/gear/augment/integrated_security_hud
 	allowed_roles = SECURITY_ROLES

--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -1,12 +1,9 @@
 /datum/gear/augment/glare_dampeners
 	allowed_roles = TECHNICAL_ROLES
 
-/datum/gear/augment/integrated_health_hud
-	allowed_roles = list(\
-	/datum/job/cmo, /datum/job/senior_doctor, /datum/job/doctor,\
-	/datum/job/doctor_trainee, /datum/job/explorer_medic,\
-	/datum/job/psychiatrist, /datum/job/chemist, /datum/job/roboticist, /datum/job/explorer_medic)
-
+/datum/gear/augment/integrated_health_hud/New()
+  allowed_roles = MEDICAL_ROLES + /datum/job/explorer_medic
+  ..()
 /datum/gear/augment/integrated_security_hud
 	allowed_roles = SECURITY_ROLES
 


### PR DESCRIPTION
# Описание
Фикс доступов в loadout для КМ и полевого медика. 
У КМ в ящике есть мезоны, но почему то не было возможность взять их из loadout .

## Основные изменения
Полквой медик может выбрать медхуд в префах.
КМ может выбрать мезоны в префах.