### PR TITLE
tweak: change recipe for craftable laser

### DIFF
--- a/infinity/code/modules/projectiles/guns/energy/laser_handmade.dm
+++ b/infinity/code/modules/projectiles/guns/energy/laser_handmade.dm
@@ -198,7 +198,7 @@
 		if(15)
 			if(istype(W,/obj/item/stack/material) && W.get_material_name() == MATERIAL_GLASS)
 				var/obj/item/stack/material/M = W
-				if(M.use(40))
+				if(M.use(5))
 					to_chat(user, SPAN_NOTICE("You install lenses and scope."))
 					buildstate++
 				else


### PR DESCRIPTION
# Описание
Изменение рецепта для сборного лазера. 
Теперь как и было задумано ранее вместо 40 стекла на одном из 18 этапов нужно теперь 5. 

Прошло голосование, но бандер умер. 
https://discord.com/channels/617003227182792704/902592595975360572/962756038703075338

:cl:
tweak: craftable laser require now 5 glass instead  of 40 
/:cl:
