### PR TITLE
bugfix: add check for dark matter influx event

### DIFF
--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -249,7 +249,7 @@
 /obj/effect/overmap/event/gravity
 	name = "dark matter influx"
 	weaknesses = OVERMAP_WEAKNESS_EXPLOSIVE
-	events = list(/datum/event/gravity)
+	//events = list(/datum/event/gravity)
 	event_icon_states = list("grav1", "grav2", "grav3", "grav4")
 	opacity = 0
 	color = "#321945"

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -249,7 +249,7 @@
 /obj/effect/overmap/event/gravity
 	name = "dark matter influx"
 	weaknesses = OVERMAP_WEAKNESS_EXPLOSIVE
-	//events = list(/datum/event/gravity)
+	events = list(/datum/event/gravity)
 	event_icon_states = list("grav1", "grav2", "grav3", "grav4")
 	opacity = 0
 	color = "#321945"

--- a/infinity/code/modules/power/gravity_generator/grav_event.dm
+++ b/infinity/code/modules/power/gravity_generator/grav_event.dm
@@ -3,7 +3,7 @@
 
 /datum/event/gravity/start()
 	var/obj/machinery/gravity_generator/main/GG = GLOB.station_gravity_generator
-	if(!GG)
+	if(!GG || !(GG.z in affecting_z))
 		log_debug("The gravity generator was not found while trying to start an event.")
 		return
 


### PR DESCRIPTION
# Описание
Фикс ивента "гравитации" при пролете темной материи.

Гуппи и Харон, пролетая темную материю, вырубают грав ген Сиерры. Что явно не так должно работать.  Была добавлена проверка на наличие гравгена на z уровне. 

:cl:
bugfix:  fix dark matter influx event
/:cl:
