### PR TITLE
RSF Languages Fix

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -96,7 +96,7 @@ RSF
 			used_energy = 200
 
 	to_chat(user, "Dispensing [product ? product : "product"]...")
-	product.dropInto(A.loc)
+	product.dropInto(A)
 
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -71,6 +71,7 @@
 		brainmob.real_name = H.real_name
 		brainmob.dna = H.dna.Clone()
 		brainmob.timeofhostdeath = H.timeofdeath
+		brainmob.languages = H.languages
 
 	if(H.mind)
 		H.mind.transfer_to(brainmob)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -540,6 +540,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	var/obj/item/device/mmi/M = tool
 	var/obj/item/organ/internal/mmi_holder/holder = new(target, 1)
 	target.internal_organs_by_name[BP_BRAIN] = holder
+	target.languages = M.brainmob.languages
 	tool.forceMove(holder)
 	holder.stored_mmi = tool
 	holder.update_from_mmi()


### PR DESCRIPTION
# Описание

Мелкофикс для роботов.

## Основные изменения

* Rapid Service Fabricator спавнит вещи на корректном тайле/столе
* Мозги продолжают помнить языки при перемещении в ММИ/ППТ

## Changelog

:cl:
bugfix: Rapid Service Fabricator now spawns items on the correct atom
bugfix: Languages are now carrying over with the brain
/:cl:
