### PR TITLE
Verne spawn weight change. Made more often. And Yacht spawn rate nerf.

### DIFF
--- a/maps/away/verne/verne.dm
+++ b/maps/away/verne/verne.dm
@@ -37,9 +37,9 @@
 	id = "awaysite_verne"
 	description = "Active CTI research ship"
 	suffixes = list("verne/verne-1.dmm", "verne/verne-2.dmm", "verne/verne-3.dmm")
-	spawn_cost = 2
+	spawn_cost = 1
 	player_cost = 4
-	spawn_weight = 0.33
+	spawn_weight = 1
 	area_usage_test_exempted_root_areas = list(/area/verne)
 	shuttles_to_initialise = list(
 		/datum/shuttle/autodock/overmap/verne,

--- a/maps/away_inf/yacht/yacht.dm
+++ b/maps/away_inf/yacht/yacht.dm
@@ -30,7 +30,7 @@
 	suffixes = list("yacht/yacht.dmm")
 	spawn_cost = 0.5
 	player_cost = 2 // Нынешнее значение основано на количестве игроков в авейке ~bear1ake
-	spawn_weight = 1 // было spawn_weight = 0.67
+	spawn_weight = 0.67
 	area_usage_test_exempted_root_areas = list(/area/yacht)
 
 /obj/effect/shuttle_landmark/nav_yacht/nav1

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
-	spawn_cost = 1 // INF, было spawn_cost = 1.5
+	spawn_cost = 2000 // INF, было spawn_cost = 1.5
 	player_cost = 1 // INF, было player_cost = 4 | Нынешнее значение основано на количестве игроков в авейке ~bear1ake
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK


### PR DESCRIPTION
# Описание
Повышен шанс спавна  авейки Верне. И уменьшен для яхты.  Отключен краш под. 

По размеру научное судно Верне чуть ли не больше Либерии.  Очень жаль, что такая авейка почти никогда не появляется,  и многие вообще не знают,  что она существует. Сам её функционал очень богат. 

:cl:
tweak: increased chance for Verne to spawn
/:cl:
