### PR TITLE
Добавляем две коробки со стерильными перчатками на склад

### DIFF
--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -28402,6 +28402,8 @@
 /obj/item/storage/box/syringes,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/tiled/white,
 /area/medical/maintenance_equipstorage)
 "aYZ" = (


### PR DESCRIPTION
В лазарете по дефолту имеется аж три коробки со стерильными масочками, но при этом всего одна коробка с стерильными перчатками, что выглядит нелогично и просчётом маппера, а следовательно - багом. Я исправил это, добавив на склад меда на 2-й палубе ещё 2 коробки с перчатками. Это не даёт никакого объективного преимущества игрокам, и исправляет неравенство между масками и перчатками. 

:cl:
bugfix: Добавил 2 дополнительные коробки с стерильными перчатками на склад лазарета, уровняв их количество с масками.
/:cl:
