### PR TITLE
Languages Fix 2

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -600,6 +600,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 			SPAN_NOTICE("\The [user] removes \the [mmi] from \the [target]'s [affected.name] with \the [tool]."), \
 			SPAN_NOTICE("You  remove \the [mmi] from \the [target]'s [affected.name] with \the [tool]."))
 			target.remove_implant(mmi, TRUE, affected)
+			mmi.brainmob.languages = target.languages
 		else
 			user.visible_message( \
 			SPAN_NOTICE("\The [user] could not find anything inside [target]'s [affected.name]."), \


### PR DESCRIPTION
# Описание

Фикс на предыдущий фикс.

## Основные изменения

* Мозги раундстартовых ППТ больше не забывают языки при переподключении к своему телу/при пересадке в другое.
