### PR TITLE
BUGFIX. Distress Call and apostrophe in ship titles

### DIFF
--- a/infinity/code/modules/overmap/ships/ship.dm
+++ b/infinity/code/modules/overmap/ships/ship.dm
@@ -7,4 +7,4 @@
 	. = ..()
 	if(distress == 1)
 		animate(src, transform = matrix() * 1.4, color = "#ff2222", time = 5)
-		animate(transform = matrix() * 1, color = initial(color), time = 5)
+

--- a/infinity/code/modules/overmap/ships/ship.dm
+++ b/infinity/code/modules/overmap/ships/ship.dm
@@ -5,6 +5,6 @@
 
 /obj/effect/overmap/visitable/ship/Process()
 	. = ..()
-	if(distress == 1)
+	if(distress)
 		animate(src, transform = matrix() * 1.4, color = "#ff2222", time = 5)
        	animate(transform = matrix(), color = initial(color), time = 5)

--- a/infinity/code/modules/overmap/ships/ship.dm
+++ b/infinity/code/modules/overmap/ships/ship.dm
@@ -7,4 +7,4 @@
 	. = ..()
 	if(distress)
 		animate(src, transform = matrix() * 1.4, color = "#ff2222", time = 5)
-       	animate(transform = matrix(), color = initial(color), time = 5)
+		animate(transform = matrix(), color = initial(color), time = 5)

--- a/infinity/code/modules/overmap/ships/ship.dm
+++ b/infinity/code/modules/overmap/ships/ship.dm
@@ -7,4 +7,4 @@
 	. = ..()
 	if(distress == 1)
 		animate(src, transform = matrix() * 1.4, color = "#ff2222", time = 5)
-       	animate(transform = matrix() * 1, color = initial(color), time = 5)
+       	animate(transform = matrix(), color = initial(color), time = 5)

--- a/infinity/code/modules/overmap/ships/ship.dm
+++ b/infinity/code/modules/overmap/ships/ship.dm
@@ -7,4 +7,4 @@
 	. = ..()
 	if(distress == 1)
 		animate(src, transform = matrix() * 1.4, color = "#ff2222", time = 5)
-
+       	animate(transform = matrix() * 1, color = initial(color), time = 5)

--- a/infinity/code/modules/overmap/ships/ship.dm
+++ b/infinity/code/modules/overmap/ships/ship.dm
@@ -5,6 +5,6 @@
 
 /obj/effect/overmap/visitable/ship/Process()
 	. = ..()
-	if(distress)
-		animate(src, transform = matrix()*1.4, color = "#ff2222", time = 5)
-		animate(src, transform = matrix(), color = initial(color), time = 10)
+	if(distress == 1)
+		animate(src, transform = matrix() * 1.4, color = "#ff2222", time = 5)
+		animate(transform = matrix() * 1, color = initial(color), time = 5)

--- a/maps/away_inf/ascent/ascent.dm
+++ b/maps/away_inf/ascent/ascent.dm
@@ -1,4 +1,4 @@
-#define DAMAGED_ASCENT_COLONY_SHIP_NAME "\improper Ascent's Colony Ship"
+#define DAMAGED_ASCENT_COLONY_SHIP_NAME "\improper Ascent Colony Ship"
 
 #include "ascent_areas.dm"
 #include "ascent_jobs.dm"


### PR DESCRIPTION
# Описание

Distress Call работает на карте системы. 
И Ascent Colony Ship дает настраивать навыки (вскрывая небольшую проблему)

## Основные изменения

Distress Call заставляет иконку мигать. Достигнуто засчет удаления второй ссылки на иконку корабля в файле.
Ascent Ship доступен к настройке навыков. Апостроф в названии ломал эту возможность. 

## Скриншоты
1. 
![Работа1](https://user-images.githubusercontent.com/100538205/168638669-5700a16e-6024-4030-a3a8-95d8811b885a.JPG)
![Работа2](https://user-images.githubusercontent.com/100538205/168638672-52f2817c-d88b-45c4-b8e0-68f85916f8de.JPG)
![Работа3](https://user-images.githubusercontent.com/100538205/168638675-c150b106-cd5c-41b1-a047-afac2e91c9a4.JPG)
2.
![Работа4](https://user-images.githubusercontent.com/100538205/168638660-16417205-f146-4485-b779-8e9f6cfff8bd.JPG)



## Changelog

:cl:
bugfix: Distress Call заставляет иконку корабля мигать на Overmap
/:cl:
