### PR TITLE
Add: Medical stuff in Microlathe. IV bag for Autolathe

### DIFF
--- a/code/modules/fabrication/designs/general/designs_medical.dm
+++ b/code/modules/fabrication/designs/general/designs_medical.dm
@@ -19,18 +19,21 @@
 
 /datum/fabricator_recipe/medical/beaker
 	path = /obj/item/reagent_containers/glass/beaker
+	fabricator_types = list(FABRICATOR_CLASS_MICRO)
 
 /datum/fabricator_recipe/medical/beaker_large
 	path = /obj/item/reagent_containers/glass/beaker/large
+	fabricator_types = list(FABRICATOR_CLASS_MICRO)
 
 /datum/fabricator_recipe/medical/beaker_insul
 	path = /obj/item/reagent_containers/glass/beaker/insulated
-
+	fabricator_types = list(FABRICATOR_CLASS_MICRO)
 /datum/fabricator_recipe/medical/beaker_insul_large
 	path = /obj/item/reagent_containers/glass/beaker/insulated/large
-
+	fabricator_types = list(FABRICATOR_CLASS_MICRO)
 /datum/fabricator_recipe/medical/vial
 	path = /obj/item/reagent_containers/glass/beaker/vial
+	fabricator_types = list(FABRICATOR_CLASS_MICRO)
 
 /datum/fabricator_recipe/medical/syringe
 	path = /obj/item/reagent_containers/syringe
@@ -43,3 +46,6 @@
 
 /datum/fabricator_recipe/medical/hypospray/autoinjector
 	path = /obj/item/reagent_containers/hypospray/autoinjector/empty
+
+/datum/fabricator_recipe/medical/ivbag
+	path = /obj/item/reagent_containers/ivbag

--- a/code/modules/fabrication/fabricator_microlathe.dm
+++ b/code/modules/fabrication/fabricator_microlathe.dm
@@ -9,9 +9,9 @@
 	base_type = /obj/machinery/fabricator/micro
 	fabricator_class = FABRICATOR_CLASS_MICRO
 	base_storage_capacity = list(
-		/material/aluminium = 5000,
-		/material/plastic =   5000,
-		/material/glass   = 5000
+		/material/aluminium = 20000,
+		/material/plastic =   20000,
+		/material/glass   = 20000
 	)
 	machine_name = "microlathe"
 	machine_desc = "A smaller-sized autolathe, typically used for cutlery, dinnerware, and drinking glasses."

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -10,6 +10,7 @@
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
 	w_class = ITEM_SIZE_TINY
+	matter = list(MATERIAL_STEEL = 250, MATERIAL_PLASTIC = 700)
 	volume = 120
 	possible_transfer_amounts = "0.2;1;2"
 	amount_per_transfer_from_this = REM


### PR DESCRIPTION
# Описание
В микролат добавлены рецепты мерных стаканов и колб для гипоспрея. Для той же химии использовать барные кувшины и стаканы как-то странно, да и не поддерживаются они другой аппаратурой, добавлять большой автолат это слишком.

Одобрено:
https://discord.com/channels/617003227182792704/924974001971933204/977952861726072884

## Основные изменения

Бикеры обычные и теплоизолированные в минилат.
Пробирка для гипоспрея в минилат.
Пустой пакет крови в автолат. 
Увеличен стандартный размер хранилища минилата. 

## Changelog
:cl:
rscadd: added blood pack  to Autolathe
rscadd: added medical beakers and vial to Microlathe
balance: Microlathe  storage buff
/:cl:
