### PR TITLE
Mage Spells Fix

### DIFF
--- a/code/modules/spells/targeted/equip/dyrnwyn.dm
+++ b/code/modules/spells/targeted/equip/dyrnwyn.dm
@@ -9,7 +9,7 @@
 	invocation = "Anrhydeddu Fi!"
 	invocation_type = SpI_SHOUT
 	spell_flags = INCLUDEUSER
-	range = -1
+	range = 0
 	level_max = list(Sp_TOTAL = 1, Sp_SPEED = 0, Sp_POWER = 1)
 	duration = 300 //30 seconds
 	max_targets = 1

--- a/code/modules/spells/targeted/equip/seed.dm
+++ b/code/modules/spells/targeted/equip/seed.dm
@@ -15,7 +15,7 @@
 	cooldown_min = 200 //20 seconds
 	level_max = list(Sp_TOTAL = 3, Sp_SPEED = 3, Sp_POWER = 0)
 
-	range = -1
+	range = 0
 	max_targets = 1
 
 	hud_state = "wiz_seed"

--- a/code/modules/spells/targeted/equip/shield.dm
+++ b/code/modules/spells/targeted/equip/shield.dm
@@ -6,7 +6,7 @@
 	invocation = "Sia helda!"
 	invocation_type = SpI_SHOUT
 	spell_flags = INCLUDEUSER | NEEDSCLOTHES
-	range = -1
+	range = 0
 	max_targets = 1
 
 	compatible_mobs = list(/mob/living/carbon/human)

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -135,7 +135,7 @@
 	invocation = "Poli'crakata!"
 	invocation_type = SpI_SHOUT
 	spell_flags = INCLUDEUSER
-	range = -1
+	range = 0
 	duration = 150
 	charge_max = 600
 	cooldown_min = 300


### PR DESCRIPTION
# Описание

Чинит заклинания мага, которые сейчас не работают, а именно: Polymorph, Summon Shield, Summon Seed, Summon Dyrnwyn.
Все они имеют эффект только на самого мага, но сейчас не работают из-за отрицательной дальности (из-за которой сама цель заклинания, Маг, не может быть доступен).

Все заклинания работоспособны, но:
1. У Щита нет спрайта. Однако, в руке он виден. Будет сложно поднять, если выпадет. Однако, это к спрайтерам.
2. Dyrnwyn не имеет кулдауна каста. Я не стал это править, так как за каждый призванный меч, маг получает урон огнём по руке, да и урон у меча ниже, чем у тулбокса. Ну и да, маг призывающий и затем кидающий пылающие огнём мечи выглядит круто.

## Основные изменения

* Отредактирована дальность заклинаний Polymorph, Summon Shield, Summon Seed, Summon Dyrnwyn, делая их работоспособными.


:cl:
bugfix: fixed a few things
/:cl:
