### PR TITLE
gep rebalance

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -110,7 +110,7 @@ SUBSYSTEM_DEF(supply)
 					// Must sell ore detector disks in crates
 					if(istype(A, /obj/item/disk/survey))
 						var/obj/item/disk/survey/D = A
-						add_points_from_source(round(D.Value() * 0.005), "gep")
+						add_points_from_source(round(D.Value() * 0.05), "gep")
 
 			qdel(AM)
 


### PR DESCRIPTION
# Описание

* Ребаланс стоимости продажи диска с геологическими данными в 10 раз.

# Авторство

код @keIgaras
идея @RomanMinaev

## Основные изменения
Good Explorer Point - GEP
При использовании Ore detector на планете или астероиде, вы считываете данные о подземных месторождениях, а так же на диск внутри него записываются GEP, в данный момент цена GEP неадекватно занижена.

Сейчас стоимость GEP варьируется от количества, есть 3 градации, от 0 до 10000, от 10000 тысяч до 30000, от 30000 и более.
В первом варианте вы получаете 7% от количества GEP умноженное на 0.005 в виде очков снабжения.
Во втором варианте вы получаете 10% от количества GEP умноженное на 0.005 в виде очков снабжения.
В третьем варианте вы получаете 15% от количества GEP умноженное на 0.005 в виде очков снабжения.
Это безумно мало
Приведу пример, вы добыли 16450 GEP, и после всех математических вычислений вы получите 8 ОЧКОВ СНАБЖЕНИЯ.


:cl:
rscadd: gep стоят в 10 раз больше
/:cl: