### PR TITLE
Rubber bullets holodamage improvement

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -146,11 +146,11 @@
 	name = "rubber bullet"
 	damage_flags = 0
 	damage = 5
-	agony = 30
+	agony = 40
 	embed = FALSE
 
 /obj/item/projectile/bullet/pistol/rubber/holdout
-	agony = 20
+	agony = 30
 
 //4mm. Tiny, very low damage, does not embed, but has very high penetration. Only to be used for the experimental SMG.
 /obj/item/projectile/bullet/flechette


### PR DESCRIPTION
# Описание

В целях повышения использования резиновых пуль как средства нелетального задержания преступников, а также нелетального задержания целей антагонистов поднят голоурон для резиновых пистолетных пуль малого и среднего калибра

## Основные изменения

* Пистолетная пуля - урон поднят с 30 до 40 голоурона 
* Пуля дамского, прошу прощения, пистолета скрытного ношения - урон поднят с 20 до 30 голоурона



## Changelog

* Holodamage raised from 30 to 40 for standart pistols
* Holodamage raised from 20 to 30 for holdout pistols

:cl:
balance: rebalanced something
/:cl:
