### PR TITLE
job/roboticist skill buff

### DIFF
--- a/maps/sierra/job/jobs_research.dm
+++ b/maps/sierra/job/jobs_research.dm
@@ -131,7 +131,9 @@
 			SKILL_DEVICES		=	SKILL_ADEPT,
 			SKILL_EVA			=	SKILL_ADEPT,
 			SKILL_ANATOMY		=	SKILL_ADEPT,
-			SKILL_MECH			=	HAS_PERK
+			SKILL_MECH			=	HAS_PERK,
+			SKILL_MEDICAL		=	SKILL_BASIC,
+			SKILL_ELECTRICAL	=	SKILL_ADEPT
 		)
 
 	max_skill = list(
@@ -144,7 +146,7 @@
 			SKILL_ANATOMY		=	SKILL_EXPERT
 		)
 
-	skill_points = 20
+	skill_points = 22
 
 	access = list(
 			access_robotics,


### PR DESCRIPTION
# Описание
Бафф стартовых навыков роботеха.

- 2 свободных поинта (с 20 до 22, что поднимет их на один уровень с обычным учёным),
- медицина          -> базовая       (сейчас - необученный)
- электротехника -> обученный (сейчас - необученный).

## Changelog
:cl:
balance: skill_points = 20 -> 22. Add SKILL_ELECTRICAL and  SKILL_MEDICAL	      	
/:cl:
