### PR TITLE
REMOVE VOX

### DIFF
--- a/maps/away_inf/liberia/liberia_jobs.dm
+++ b/maps/away_inf/liberia/liberia_jobs.dm
@@ -92,7 +92,7 @@
 	minimal_player_age = 0
 	create_record = 0
 	whitelisted_species = null
-	blackblacklisted_species = list(SPECIES_VOX, SPECIES_ALIEN, SPECIES_GOLEM, SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_MONARCH_WORKER, SPECIES_MONARCH_QUEEN, SPECIES_XENO)
+	blacklisted_species = list(SPECIES_VOX, SPECIES_ALIEN, SPECIES_GOLEM, SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_MONARCH_WORKER, SPECIES_MONARCH_QUEEN, SPECIES_XENO)
 	alt_titles = list(
 		"Merchant Security" = /decl/hierarchy/outfit/job/liberia/merchant/security,
 		"Merchant Engineer" = /decl/hierarchy/outfit/job/liberia/merchant/engineer,

--- a/maps/away_inf/liberia/liberia_jobs.dm
+++ b/maps/away_inf/liberia/liberia_jobs.dm
@@ -92,7 +92,7 @@
 	minimal_player_age = 0
 	create_record = 0
 	whitelisted_species = null
-	blacklisted_species = list(SPECIES_ALIEN, SPECIES_GOLEM, SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_MONARCH_WORKER, SPECIES_MONARCH_QUEEN, SPECIES_XENO)
+	blackblacklisted_species = list(SPECIES_VOX, SPECIES_ALIEN, SPECIES_GOLEM, SPECIES_MANTID_GYNE, SPECIES_MANTID_ALATE, SPECIES_MONARCH_WORKER, SPECIES_MONARCH_QUEEN, SPECIES_XENO)
 	alt_titles = list(
 		"Merchant Security" = /decl/hierarchy/outfit/job/liberia/merchant/security,
 		"Merchant Engineer" = /decl/hierarchy/outfit/job/liberia/merchant/engineer,


### PR DESCRIPTION
Фикс наличия воксов на Либерии

# Описание

Данный пулреквест сделан с целью внесения ясности в РП процесс в соответствии с лором Бейстейшн 12, где воксы являются явно не дружелюбной расой, которая способна к кооперации с т.н. ими "мясом". В свою очередь все цивилизованные расы и фракции будут избегать контакта с воксами и стрелять на поражение при их виде. 

## Основные изменения

* Добавлен блеклист на Воксов в профессию помощника торговца


:cl:
rscdel: removed old things
/:cl:
