### PR TITLE
Maptweak: handrails for GUP, exosuit frame for Verne

### DIFF
--- a/maps/away/verne/verne-2.dmm
+++ b/maps/away/verne/verne-2.dmm
@@ -1734,25 +1734,7 @@
 "iM" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/plastic,
-/obj/item/mech_component/chassis/light,
-/obj/item/mech_component/control_module,
-/obj/item/mech_component/manipulators/light,
-/obj/item/mech_component/propulsion/tracks,
-/obj/item/mech_component/sensors/light,
-/obj/item/mech_equipment/clamp,
-/obj/item/mech_equipment/light,
-/obj/item/mech_equipment/drill,
-/obj/item/mech_equipment/mounted_system/extinguisher,
-/obj/item/cell/high,
-/obj/item/robot_parts/robot_component/armour/exosuit,
-/obj/item/robot_parts/robot_component/radio,
-/obj/item/robot_parts/robot_component/actuator,
-/obj/item/circuitboard/exosystem/utility,
-/obj/item/circuitboard/exosystem/engineering,
-/obj/item/robot_parts/robot_component/diagnosis_unit,
-/obj/item/robot_parts/robot_component/camera,
-/obj/item/robot_parts/robot_component/actuator,
+/obj/structure/heavy_vehicle_frame,
 /turf/simulated/floor/tiled/techfloor,
 /area/verne/engineering/workshop)
 "iU" = (
@@ -3858,6 +3840,25 @@
 /turf/simulated/floor/tiled,
 /area/verne/stairs/two)
 "zA" = (
+/obj/structure/closet/crate/plastic,
+/obj/item/mech_component/chassis/light,
+/obj/item/mech_component/control_module,
+/obj/item/mech_component/manipulators/light,
+/obj/item/mech_component/propulsion/tracks,
+/obj/item/mech_component/sensors/light,
+/obj/item/mech_equipment/clamp,
+/obj/item/mech_equipment/light,
+/obj/item/mech_equipment/drill,
+/obj/item/mech_equipment/mounted_system/extinguisher,
+/obj/item/cell/high,
+/obj/item/robot_parts/robot_component/armour/exosuit,
+/obj/item/robot_parts/robot_component/radio,
+/obj/item/robot_parts/robot_component/actuator,
+/obj/item/circuitboard/exosystem/utility,
+/obj/item/circuitboard/exosystem/engineering,
+/obj/item/robot_parts/robot_component/diagnosis_unit,
+/obj/item/robot_parts/robot_component/camera,
+/obj/item/robot_parts/robot_component/actuator,
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
@@ -4973,11 +4974,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/verne/xenosci)
-"II" = (
-/obj/effect/floor_decal/techfloor/orange,
-/obj/structure/heavy_vehicle_frame,
-/turf/simulated/floor/tiled/techfloor,
-/area/verne/engineering/workshop)
 "IK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -14375,7 +14371,7 @@ Fd
 xU
 qj
 JJ
-II
+hH
 Sd
 Sd
 Sd

--- a/maps/away/verne/verne-2.dmm
+++ b/maps/away/verne/verne-2.dmm
@@ -4973,6 +4973,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/verne/xenosci)
+"II" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/structure/heavy_vehicle_frame,
+/turf/simulated/floor/tiled/techfloor,
+/area/verne/engineering/workshop)
 "IK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -14370,7 +14375,7 @@ Fd
 xU
 qj
 JJ
-hH
+II
 Sd
 Sd
 Sd

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -1009,7 +1009,7 @@
 	dir = 8;
 	name = "west bump";
 	pixel_x = -25;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -5852,7 +5852,7 @@
 	dir = 4;
 	name = "west bump";
 	pixel_x = 24;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -17696,6 +17696,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/structure/handrail,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "BY" = (
@@ -18778,6 +18779,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/structure/handrail,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "DI" = (
@@ -20741,12 +20743,12 @@
 "GZ" = (
 /obj/structure/bed/chair/shuttle/green{
 	dir = 1;
-	req_access = list(list("ACCESS_EXPEDITION_SHUTTLE", "ACCESS_EXPEDITION_SHUTTLE_HELM","ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPEDITION_SHUTTLE","ACCESS_EXPEDITION_SHUTTLE_HELM","ACCESS_ENGINEERING"))
 	},
 /obj/machinery/power/apc/charon{
 	name = "south bump";
 	pixel_y = -24;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /obj/machinery/camera/network/exploration_shuttle{
 	c_tag = "Charon - Seats Place Compartment";
@@ -21637,7 +21639,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -22416,7 +22418,7 @@
 	},
 /obj/item/gun/energy/laser{
 	desc = "A Hephaestus Industries G40E carbine, designed to kill with concentrated energy blasts. He seems to lack some details.";
-	origin_tech = list("combat" = 2, "magnets" = 1);
+	origin_tech = list("combat"=2,"magnets"=1);
 	projectile_type = /obj/item/projectile/beam/practice
 	},
 /turf/simulated/floor/plating,
@@ -22553,7 +22555,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /turf/simulated/floor/plating,
 /area/exploration_shuttle/power)
@@ -26416,6 +26418,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/handrail,
 /turf/simulated/floor/tiled,
 /area/guppy_hangar/start)
 "Ql" = (
@@ -29016,7 +29019,7 @@
 	dir = 8;
 	name = "west bump";
 	pixel_x = -25;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
@@ -29959,7 +29962,7 @@
 /obj/machinery/power/apc/charon{
 	name = "south bump";
 	pixel_y = -24;
-	req_access = list(list("ACCESS_EXPLORER", "ACCESS_ENGINEERING"))
+	req_access = list(list("ACCESS_EXPLORER","ACCESS_ENGINEERING"))
 	},
 /obj/effect/floor_decal/borderfloor{
 	color = null;


### PR DESCRIPTION
## Основные изменения

* У челнока GUP появились 3 поручня: 1 в кабине, еще 2 в шлюзе. Больше не нужно пихать людей в стазис поды, если экипаж превышает 3 человека - достаточно пристегнуться к таким штукам.
* На Verne существует готовый набор для сборки меха, но там не хватало главной детали - самого каркаса. Теперь он там появился, и меха можно собрать самостоятельно и без помощи админов.

:cl: Neonvolt
maptweak: added handrails for GUP
maptweak: added exosuit frame for Verne
/:cl:
