### PR TITLE
jetpacks are now in cargo

### DIFF
--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -80,7 +80,7 @@
 	contains = list(/obj/item/grenade/light = 8)
 	cost = 20
 	containername = "illumination grenade crate"
-	
+
 /decl/hierarchy/supply_pack/science/space_bike
 	name = "Exploration - Space-bike"
 	contains = list(/obj/vehicle/bike/thermal)
@@ -94,3 +94,9 @@
 	contains = list(/obj/structure/anomaly_container)
 	containertype = /obj/structure/largecrate
 	containername = "anomaly container crate"
+
+/decl/hierarchy/supply_pack/science/jetpack_crate
+	name = "Equipment - Jetpacks"
+	contains = list(/obj/item/tank/jetpack/oxygen,/obj/item/tank/jetpack/carbondioxide,/obj/item/tank/jetpack/carbondioxide)
+	cost = 75
+	containername = "Jetpacks crate"


### PR DESCRIPTION
# Описание
Добавлена возможность заказать джетпаки в карго.

Прошедшая предложка
https://discord.com/channels/617003227182792704/755125334097133628/989277813611855895
## Основные изменения
За 75 поинтов в карго можно заказать три джетпака.  Один на кислороде и два на  карбоне.

## Changelog
:cl:
experiment: jetpack can be ordered in cargo
/:cl:
