### PR TITLE
IPC skills from age Tweak

### DIFF
--- a/code/modules/species/station/machine.dm
+++ b/code/modules/species/station/machine.dm
@@ -144,6 +144,6 @@
 /datum/species/machine/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
 	switch(age)
 		if(0 to 10)    . = 0
-		if(10 to 20)   . =  4
-		if(20 to 40)   . =  8
+		if(11 to 20)   . =  4
+		if(21 to 40)   . =  8
 		else           . =  6

--- a/code/modules/species/station/machine.dm
+++ b/code/modules/species/station/machine.dm
@@ -140,3 +140,10 @@
 
 /datum/species/machine/can_float(mob/living/carbon/human/H)
 	return FALSE
+
+/datum/species/machine/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
+	switch(age)
+		if(0 to 10)    . = 0
+		if(10 to 20)   . =  4
+		if(20 to 40)   . =  8
+		else           . =  6


### PR DESCRIPTION
# Описание



## Основные изменения

* Молодые ИПС теперь получают больше дополнительных очков за каждые десять лет своего существования и обучения.
* ИПС, которым более 40 лет считаются устаревшими и получают меньше дополнительных очков.
* Теперь очки соответствуют лору и логике.

| Было                   | Стало                  |
| ---------------------- | ---------------------- |
| 0-22 лет = 0 очков | 0-10 лет = 0 очков |
| 23-30 лет = 3 очка | 11-20 лет = 4 очка |
| 31-45 лет = 6 очков | 21-40 лет = 8 очков |
| 46+лет = 8 очков | 41+лет = 6 очков |

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: Изменена зависимость очков навыков ИПС от их возраста в соответствии с лором.
balance: Старые ИПС имеют меньше очков навыков чем более свежие модели.
/:cl:
