### PR TITLE
Mapfix: Mental Health

### DIFF
--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -9129,7 +9129,7 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue2,
@@ -9163,7 +9163,7 @@
 	name = "Therapy Room"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/medical/mentalhealth)
 "aps" = (
 /obj/machinery/barrier,
@@ -10020,7 +10020,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "aqZ" = (
 /obj/structure/table/woodentable/walnut,
@@ -13931,19 +13931,18 @@
 /area/hallway/primary/firstdeck/aft)
 "azh" = (
 /obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "azi" = (
 /obj/random/vendor,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/lime/border{
-	dir = 1
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/dungeon_master_lounge)
 "azj" = (
@@ -18728,13 +18727,13 @@
 	pixel_x = 26;
 	pixel_y = 2
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "aFE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33229,13 +33228,13 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "bcE" = (
 /obj/structure/table/standard,
@@ -36710,6 +36709,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/locker)
+"bYa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/cola{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/dungeon_master_lounge)
 "caY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -36740,14 +36758,20 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "ceA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -36974,7 +36998,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "dnw" = (
 /obj/machinery/door/airlock/external/escapepod{
@@ -37102,13 +37126,13 @@
 /obj/random/date_based/christmas/xmaslights{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "dLC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -37125,7 +37149,7 @@
 /area/medical/infirmreception)
 "dPt" = (
 /obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "dQe" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
@@ -38200,6 +38224,23 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology/xenoflora)
+"gWK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/dungeon_master_lounge)
 "hcG" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -38212,13 +38253,13 @@
 /obj/random/date_based/christmas/xmaslights{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "hdm" = (
 /obj/structure/lattice,
@@ -38316,13 +38357,13 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/item/folder/white,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "hEV" = (
 /obj/machinery/atmospherics/unary/freezer{
@@ -38444,7 +38485,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "hRe" = (
 /obj/machinery/status_display,
@@ -38544,7 +38585,7 @@
 	dir = 4;
 	id_tag = "mental_health_door"
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/medical/mentalhealth)
 "hYX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -38684,9 +38725,9 @@
 	dir = 1;
 	pixel_y = -29
 	},
-/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "ioG" = (
 /obj/effect/floor_decal/borderfloor{
@@ -39036,8 +39077,12 @@
 /obj/random/vendor{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lime/border,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/dungeon_master_lounge)
@@ -39111,26 +39156,11 @@
 /area/medical/mentalhealth/therapyroom)
 "jMH" = (
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
+	dir = 9;
+	pixel_x = -16
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/cola{
-	dir = 1
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/dungeon_master_lounge)
@@ -39251,7 +39281,7 @@
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "kuA" = (
 /obj/effect/floor_decal/techfloor{
@@ -40027,20 +40057,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore_stairwell)
 "miF" = (
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
-	},
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
+	dir = 10;
+	pixel_y = 16
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/dungeon_master_lounge)
 "mrL" = (
@@ -40621,13 +40644,13 @@
 	dir = 1
 	},
 /obj/item/toy/figure/psychologist,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "nQB" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -40982,7 +41005,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "oXn" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -41419,10 +41442,10 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/dungeon_master_lounge)
 "qiE" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/carpet/blue2{
 	dir = 8
 	},
-/obj/effect/floor_decal/carpet/blue2{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue2,
@@ -41578,7 +41601,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "qYL" = (
 /obj/effect/floor_decal/borderfloor,
@@ -41700,13 +41723,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "rOo" = (
 /obj/effect/floor_decal/techfloor{
@@ -43032,7 +43055,7 @@
 /area/rnd/misc_lab)
 "vZt" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "wck" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -43435,7 +43458,7 @@
 /obj/structure/bed/chair/office/comfy/brown{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "xLj" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -43556,16 +43579,19 @@
 /obj/random/date_based/christmas/xmaslights{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/borderfloor/corner2{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/medical/mentalhealth)
 "yjj" = (
 /obj/machinery/light,
@@ -70584,13 +70610,13 @@ vZt
 xJQ
 ijX
 arA
-miF
-rab
+arA
+gWK
 aAu
 aDW
 aHl
-rab
-jMH
+bYa
+arA
 arA
 xCV
 aNm
@@ -70787,11 +70813,11 @@ dbS
 azh
 arA
 azi
-rab
+miF
 ulk
 aFH
 aHm
-rab
+jMH
 jsp
 arA
 sWW


### PR DESCRIPTION
# Описание

Это мелкий фикс моего предыдущего ПРа, основанный на фидбеке игроков.

## Основные изменения

* Обсерватории возвращена ее изначальная полностью "округлая" форма.
* Пол в офисе менталиста заменен на более темный аналог.
* Лампы в комнате для терапии заменены на более тусклые лампочки накаливания.

## Скриншот
![image](https://user-images.githubusercontent.com/83385197/179315630-aa985cfb-dece-4ccc-8ddc-8d87d4908029.png)

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Neonvolt
mapfix: revert Observatory changes
mapfix: darkened Mental Health office floor
mapfix: darkened Therapy Room lighting
/:cl:
