### PR TITLE
Фикс остатков выстрела на одежде.// Swab Residue Fix

### DIFF
--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -83,8 +83,10 @@
 	report.info = "<b>Scanned item:</b><br>[scaned_object]<br><br>"
 	if("gunshot_residue" in evidence)
 		report.info += "<b>Gunpowder residue analysis report #[report_num]</b>: [scaned_object]<br>"
-		if(evidence["gunshot_residue"])
-			report.info += "Residue from a [evidence["gunshot_residue"]] bullet detected."
+		if(LAZYLEN(evidence["gunshot_residue"]))
+			report.info += "Residue from the following bullets detected:"
+			for(var/residue in evidence["gunshot_residue"])
+				report.info += "<span class='notice'>[residue]</span><br><br>"
 		else
 			report.info += "No gunpowder residue found."
 	if("fibers" in evidence)


### PR DESCRIPTION
Swab fix for residue

# Описание
Поиграл на на криминалисте, и понял что тут немного сломанная криминалистика. Быстрофикс

## Основные изменения
Теперь остатки выстрелов на одежде полноценно работают при обследовании в микроскопе.


## Скриншоты
БЫЛО 
![image](https://user-images.githubusercontent.com/61974560/179425036-dc3fb5e2-8da1-4059-8e59-e978a0b691cc.png)
СТАЛО
![image](https://user-images.githubusercontent.com/61974560/179425060-2c65bddc-f6fa-45c7-b04d-325caf0258f4.png)


## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
bugfix: Фикс микроскопа при обследовании остатков выстрелов.
/:cl:
