### PR TITLE
Быстрый эквип в портфель, тулбелт и контейнеры (на E)

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -24,6 +24,23 @@ This saves us from having to call add_fingerprint() any time something is put in
 			else
 				update_inv_r_hand(0)
 		else
+			// Try put it in their toolbelt
+			if(istype(src.belt, /obj/item/storage))
+				var/obj/item/storage/belt = src.belt
+				if(belt.can_be_inserted(I, null, 1) && belt.handle_item_insertion(I))
+					return
+			// Try put it in their backpack
+			if(istype(src.back, /obj/item/storage))
+				var/obj/item/storage/backpack = src.back
+				if(backpack.can_be_inserted(I, null, 1) && backpack.handle_item_insertion(I))
+					return
+
+			// Try to place it in any item that can store stuff, on the mob.
+			for(var/obj/item/storage/S in src.contents)
+				if(S.can_be_inserted(I, null, 1) && S.handle_item_insertion(I))
+					return
+
+			// Didn't place item :c
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
 
 /mob/living/carbon/human/proc/equip_in_one_of_slots(obj/item/W, list/slots, del_on_fail = 1)


### PR DESCRIPTION
# Описание

При нажатии на E вещь из руки пытается эквипнуться не только на персонажа, но и в тулбелт, затем в портфель, а после в любую коробку в руках и карманах (если в карман вообще можно положить какое-то хранилище предметов).

## Основные изменения

* Чуть дописан быстрый эквип для экипировки в порядке: персонаж, тулбелт, портфель, контейнеры

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: Быстрый эквип в портфель, тулбелт и контейнеры
/:cl:
