### PR TITLE
Latensy trigger rebalance

### DIFF
--- a/code/modules/psionics/complexus/complexus_latency.dm
+++ b/code/modules/psionics/complexus/complexus_latency.dm
@@ -13,5 +13,5 @@
 	var/decl/psionic_faculty/faculty_decl = SSpsi.get_faculty(faculty)
 	to_chat(owner, SPAN_DANGER("You scream internally as your [faculty_decl.name] faculty is forced into operancy by [source]!"))
 	next_latency_trigger = world.time + rand(600, 1800) * new_rank
-	if(!redactive) owner.adjustBrainLoss(rand(trigger_strength * 2, trigger_strength * 4))
+	if(!redactive) owner.adjustBrainLoss(rand(trigger_strength * 2, trigger_strength * 3))
 	return TRUE


### PR DESCRIPTION
# Описание

Изменён максимальный возможный урон при открытии псионических способностей. Данный ПР является заменой #67 
с чуть другим балансом и меньшим количеством строк.
## Основные изменения

Изменён максимальный возможны урон при открытии псионических способностей. с *4 до *3

## Changelog

Изменён максимальный возможны урон при открытии псионических способностей. с *4 до *3

:cl:
balance: rebalanced something
/:cl:
