### PR TITLE
Feat: psionics rebalance 

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -174,6 +174,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",					/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Psionic Signal",						/datum/event/minispasm,		            5,		list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Exoplanet Awakening",					/datum/event/exo_awakening,             75)
 	)
 

--- a/code/modules/psionics/equipment/cerebro_enhancers.dm
+++ b/code/modules/psionics/equipment/cerebro_enhancers.dm
@@ -25,7 +25,7 @@
 	flags_inv = 0
 	body_parts_covered = 0
 
-	max_boosted_faculties = 1
+	max_boosted_faculties = 2
 	boosted_rank = PSI_RANK_MASTER
 	unboosted_rank = PSI_RANK_OPERANT
 	boosted_psipower = 50

--- a/code/modules/psionics/equipment/null_ammo.dm
+++ b/code/modules/psionics/equipment/null_ammo.dm
@@ -1,10 +1,14 @@
 /obj/item/projectile/bullet/nullglass
 	name = "nullglass bullet"
-	damage = 40
+	damage = 30
 	shrapnel_type = /obj/item/material/shard/nullglass
 
-/obj/item/projectile/bullet/nullglass/disrupts_psionics()
-	return src
+/obj/item/projectile/bullet/nullglass/on_hit(atom/target, blocked = 0, def_zone = null)
+	. = ..()
+	var/mob/living/L = target
+	if(L.psi)
+		L.psi.stamina = max(0, L.psi.stamina - rand(15,20))
+		to_chat(L, SPAN_DANGER("You feel your psi-power leeched away by \the [src]..."))
 
 /obj/item/ammo_casing/pistol/magnum/nullglass
 	desc = "A revolver bullet casing with a nullglass coating."

--- a/code/modules/psionics/equipment/psipower_blade.dm
+++ b/code/modules/psionics/equipment/psipower_blade.dm
@@ -16,6 +16,6 @@
 	icon_state = "psiblade_long"
 
 /obj/item/psychic_power/psiblade/master/grand/paramount // Silly typechecks because rewriting old interaction code is outside of scope.
-	force = 50
+	force = 40
 	maintain_cost = 4
 	icon_state = "psiblade_long"

--- a/code/modules/psionics/equipment/psipower_tinker.dm
+++ b/code/modules/psionics/equipment/psipower_tinker.dm
@@ -16,12 +16,15 @@
 /obj/item/psychic_power/tinker/iswirecutter()
 	return emulating == "Wirecutters"
 
+/obj/item/psychic_power/tinker/ismultitool()
+	return emulating == "Multitool"
+
 /obj/item/psychic_power/tinker/attack_self()
 
 	if(!owner || loc != owner)
 		return
 
-	var/choice = input("Select a tool to emulate.","Power") as null|anything in list("Crowbar","Wrench","Screwdriver","Wirecutters","Dismiss")
+	var/choice = input("Select a tool to emulate.","Power") as null|anything in list("Crowbar","Wrench","Screwdriver","Wirecutters","Multitool","Dismiss")
 	if(!choice)
 		return
 

--- a/code/modules/psionics/equipment/psipower_tk.dm
+++ b/code/modules/psionics/equipment/psipower_tk.dm
@@ -90,6 +90,9 @@
 			sparkle()
 		owner.drop_from_inventory(src)
 
+	if(!user.psi.spend_power(2)) // So you can't spam-click kill everything that moves
+		return FALSE
+
 /obj/item/psychic_power/telekinesis/proc/sparkle()
 	set waitfor = 0
 	if(focus)

--- a/code/modules/psionics/equipment/psipower_tk.dm
+++ b/code/modules/psionics/equipment/psipower_tk.dm
@@ -1,6 +1,6 @@
 /obj/item/psychic_power/telekinesis
 	name = "telekinetic grip"
-	maintain_cost = 6
+	maintain_cost = 2
 	icon_state = "telekinesis"
 	var/atom/movable/focus
 
@@ -55,8 +55,8 @@
 	if(!target || !user || (isobj(target) && !isturf(target.loc)) || !user.psi || !user.psi.can_use() || !user.psi.spend_power(8))
 		return
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 2)
-	user.psi.set_cooldown(8)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 8)
+	user.psi.set_cooldown(32)
 
 	var/user_psi_leech = user.do_psionics_check(5, user)
 	if(user_psi_leech)
@@ -85,7 +85,7 @@
 		else
 			if(!focus.anchored)
 				var/user_rank = owner.psi.get_rank(PSI_PSYCHOKINESIS)
-				focus.throw_at(target, user_rank*2, user_rank*3, owner)
+				focus.throw_at(target, user_rank*1.5, user_rank*2, owner)
 			sleep(1)
 			sparkle()
 		owner.drop_from_inventory(src)

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -138,7 +138,7 @@
 /decl/psionic_power/coercion/mindslave
 	name =          "Mindslave"
 	cost =          28
-	cooldown =      200
+	cooldown =      300
 	use_grab =      TRUE
 	min_rank =      PSI_RANK_PARAMOUNT
 	use_description = "Grab a victim, target the eyes, then use the grab on them while on disarm intent, in order to convert them into a loyal mind-slave. The process takes some time, and failure is punished harshly."

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -19,7 +19,7 @@
 /decl/psionic_power/coercion/blindstrike
 	name =           "Blindstrike"
 	cost =           8
-	cooldown =       120
+	cooldown =       60
 	use_ranged =     TRUE
 	use_melee =      TRUE
 	min_rank =       PSI_RANK_GRANDMASTER
@@ -53,7 +53,7 @@
 /decl/psionic_power/coercion/mindread
 	name =            "Read Mind"
 	cost =            6
-	cooldown =        80
+	cooldown =        20
 	use_melee =       TRUE
 	min_rank =        PSI_RANK_OPERANT
 	use_description = "Target the head on disarm intent at melee range to attempt to read a victim's surface thoughts."
@@ -89,7 +89,7 @@
 /decl/psionic_power/coercion/agony
 	name =          "Agony"
 	cost =          8
-	cooldown =      50
+	cooldown =      30
 	use_melee =     TRUE
 	min_rank =      PSI_RANK_MASTER
 	use_description = "Target the chest or groin on disarm intent to use a melee attack equivalent to a strike from a stun baton."
@@ -109,7 +109,7 @@
 /decl/psionic_power/coercion/spasm
 	name =           "Spasm"
 	cost =           15
-	cooldown =       100
+	cooldown =       50
 	use_melee =      TRUE
 	use_ranged =     TRUE
 	min_rank =       PSI_RANK_MASTER
@@ -171,7 +171,7 @@
 /decl/psionic_power/coercion/assay
 	name =            "Assay"
 	cost =            15
-	cooldown =        100
+	cooldown =        50
 	use_grab =        TRUE
 	min_rank =        PSI_RANK_OPERANT
 	use_description = "Grab a patient, target the head, then use the grab on them while on disarm intent, in order to perform a deep coercive-redactive probe of their psionic potential."
@@ -195,7 +195,7 @@
 /decl/psionic_power/coercion/focus
 	name =          "Focus"
 	cost =          10
-	cooldown =      80
+	cooldown =      40
 	use_grab =     TRUE
 	min_rank =      PSI_RANK_OPERANT
 	use_description = "Grab a patient, target the mouth, then use the grab on them while on disarm intent, in order to cure ailments of the mind."

--- a/code/modules/psionics/faculties/energistics.dm
+++ b/code/modules/psionics/faculties/energistics.dm
@@ -94,7 +94,7 @@
 /decl/psionic_power/energistics/spark
 	name =            "Spark"
 	cost =            1
-	cooldown =        1
+	cooldown =        5
 	use_melee =       TRUE
 	min_rank =        PSI_RANK_OPERANT
 	use_description = "Target a non-living target in melee range on harm intent to cause some sparks to appear. This can light fires."

--- a/code/modules/psionics/faculties/psychokinesis.dm
+++ b/code/modules/psionics/faculties/psychokinesis.dm
@@ -36,7 +36,7 @@
 	name =            "Tinker"
 	cost =            5
 	cooldown =        10
-	min_rank =        PSI_RANK_MASTER
+	min_rank =        PSI_RANK_OPERANT
 	use_description = "Click on or otherwise activate an empty hand while on help intent to manifest a psychokinetic tool. Use it in-hand to switch between tool types."
 	admin_log = FALSE
 
@@ -50,7 +50,7 @@
 /decl/psionic_power/psychokinesis/telekinesis
 	name =            "Telekinesis"
 	cost =            5
-	cooldown =        10
+	cooldown =        20
 	use_ranged =      TRUE
 	use_manifest =    FALSE
 	min_rank =        PSI_RANK_GRANDMASTER

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -23,7 +23,7 @@
 /decl/psionic_power/redaction/skinsight
 	name =            "Skinsight"
 	cost =            3
-	cooldown =        30
+	cooldown =        25
 	use_grab =        TRUE
 	min_rank =        PSI_RANK_OPERANT
 	use_description = "Grab a patient, target the chest, then switch to help intent and use the grab on them to perform a check for wounds and damage."
@@ -40,7 +40,7 @@
 /decl/psionic_power/redaction/mend
 	name =            "Mend"
 	cost =            7
-	cooldown =        50
+	cooldown =        35
 	use_melee =       TRUE
 	min_rank =        PSI_RANK_OPERANT
 	use_description = "Target a patient while on help intent at melee range to mend a variety of maladies, such as bleeding or broken bones. Higher ranks in this faculty allow you to mend a wider range of problems."
@@ -122,7 +122,7 @@
 /decl/psionic_power/redaction/cleanse
 	name =            "Cleanse"
 	cost =            9
-	cooldown =        60
+	cooldown =        50
 	use_melee =       TRUE
 	min_rank =        PSI_RANK_GRANDMASTER
 	use_description = "Target a patient while on help intent at melee range to cleanse radiation and genetic damage from a patient."
@@ -154,7 +154,7 @@
 /decl/psionic_power/revive
 	name =            "Revive"
 	cost =            25
-	cooldown =        80
+	cooldown =        120
 	use_grab =        TRUE
 	min_rank =        PSI_RANK_PARAMOUNT
 	faculty =         PSI_REDACTION

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -180,7 +180,10 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	allowed_tools = list(
 		/obj/item/weldingtool = 100,
 		/obj/item/gun/energy/plasmacutter = 50,
-		/obj/item/psychic_power/psiblade/master = 100
+		/obj/item/psychic_power/psiblade = 75,
+		/obj/item/psychic_power/psiblade/master = 100,
+		/obj/item/psychic_power/psiblade/master/grand = 100,
+		/obj/item/psychic_power/psiblade/master/grand/paramount = 100
 	)
 
 	min_duration = 50


### PR DESCRIPTION
# Описание

Мы снова меняем цифры. На этот раз жертва - псионика. Преддверие добавлений новых психосил - старый добрый ребаланс старья.

## Основные изменения

* У Пси-усилителя теперь 2 мода на уровень Мастер за тот же ценник.
* Изменены в сторону меньшего КД псисилы уровня мастер и ниже. Занерфлен КД парамаунтовских и грандмастеровских сил (кроме лечения, там только парамаунта трогали)
* Снижен урон от телекинеза и увеличен КД на удары.
* Снижен урон от фондовского револьвера и добавлено больше урона от нуль-патронов
* Добавлена возможность лечить физические повреждения протезов всеми видами псиклинков из школы психокинетики
* В ротацию ивентов с очень малым шансом вернулся миниспазм



:cl:
balance: rebalanced something
/:cl:
