### PR TITLE
new UI for griddle, deep fryer, candy machine, cereal maker, and oven

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -305,3 +305,9 @@
 //they are here to support hotkeys
 #define INTENT_HOTKEY_LEFT  "left"
 #define INTENT_HOTKEY_RIGHT "right"
+
+// Helper procs for easy HTML browser button creation.
+#define UIBUTTON(key, label, title) "[title ? title + ": " : ""]<a href='?src=\ref[src];[key]=1'>[label]</a>"
+
+#define UI_FONT_GOOD(X) "<font color='55cc55'>[X]</font>"
+#define UI_FONT_BAD(X) "<font color='cc5555'>[X]</font>"

--- a/code/game/machinery/kitchen/cookers.dm
+++ b/code/game/machinery/kitchen/cookers.dm
@@ -1,4 +1,3 @@
-
 #define MAX_FOOD_COOK_COUNT 3
 
 #define COOKER_STRIP_RAW 0x1
@@ -67,6 +66,7 @@
 	icon_state = "[initial(icon_state)]_on"
 	started = world.time
 	threshold = 0
+	playsound(src, 'sound/machines/quiet_beep.ogg', 50, FALSE)
 
 /obj/machinery/cooker/proc/disable()
 	update_use_power(idle_power_usage)
@@ -78,46 +78,65 @@
 		I.dropInto(loc)
 	cooking.Cut()
 
-/obj/machinery/cooker/attack_hand(mob/user)
-	. = ..()
-	if (.)
-		return
+/obj/machinery/cooker/interface_interact(mob/living/user)
+	var/dat = ""
+	if (stat)
+		dat += UI_FONT_BAD("\The [src] is in no condition to operate.")
+	else
+		dat += "[UIBUTTON("empty_cooker", "Empty Ingredients", null)]<br>"
+		dat += "[UIBUTTON("toggle_state", "Turn [is_processing ? "Off" : "On"]", null)]<br>"
+		if (cook_modes.len > 1)
+			dat += "[UIBUTTON("cook_mode", "Change Cook Mode", null)] (current: [cook_mode])"
+		dat += "<br><hr>"
+		dat += "<b>Contents[is_processing ? UI_FONT_BAD(" (<i>Cooking!</i>)") : ""]:</b><br>"
+		if (!cooking.len)
+			dat += UI_FONT_BAD("None!")
+		else
+			for (var/obj/item/I in cooking)
+				dat += "[lowertext("[I]")]<br>"
+
+	var/datum/browser/popup = new(user, "cooker", name, 350, 300, src)
+	popup.set_content(dat)
+	popup.open()
+
+/obj/machinery/cooker/OnTopic(mob/user, href_list, datum/topic_state/state)
 	if (stat)
 		to_chat(user, SPAN_WARNING("\The [src] is in no condition to operate."))
 		return
-	var/option = alert(user, "", "[src] Options", "Empty", "Turn [is_processing ? "Off" : "On"]", cook_modes.len > 1 ? "Cook Mode" : null)
-	if (!option || QDELETED(src) || stat)
-		return
-	if (!Adjacent(user) || user.stat)
-		to_chat(user, SPAN_WARNING("You're not able to do that to \the [src] right now."))
-		return
-	switch (option)
-		if ("Empty")
-			if (is_processing)
-				to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
-				return
-			if (!length(cooking))
-				to_chat(user, SPAN_WARNING("\The [src] is already empty."))
-				return
+	else if (href_list["empty_cooker"])
+		if (is_processing)
+			to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
+			return
+		else if(length(cooking))
 			empty()
-		if ("Turn Off")
+		interface_interact(user)
+	else if (href_list["toggle_state"])
+		if (is_processing)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] turns off \the [src]."),
+				SPAN_NOTICE("You turn off \the [src].")
+			)
 			disable()
-			visible_message(SPAN_NOTICE("\The [user] turns off \the [src]."), SPAN_NOTICE("You turn off \the [src]."), range = 5)
-		if ("Turn On")
+		else
+			user.visible_message(
+				SPAN_NOTICE("\The [user] turns on \the [src]."),
+				SPAN_NOTICE("You turn on \the [src].")
+			)
 			enable()
-			visible_message(SPAN_NOTICE("\The [user] turns on \the [src]."), SPAN_NOTICE("You turn on \the [src]."), range = 5)
-		if ("Cook Mode")
-			if (is_processing)
-				to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
-				return
-			var/mode = input(user, "", "[src] Cook Modes") as null|anything in cook_modes
-			if (!mode || QDELETED(src) || stat)
-				return
-			if (!Adjacent(user) || user.stat)
-				to_chat(user, SPAN_WARNING("You're not able to do that to \the [src] right now."))
-				return
-			cook_mode = mode
-			to_chat(user, "The contents of \the [src] will now be [cook_modes[mode]["desc"]].")
+		interface_interact(user)
+	else if (href_list["cook_mode"])
+		if (is_processing)
+			to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
+			return
+		var/mode = input(user, "", "[src] Cook Modes") as null|anything in cook_modes
+		if (!mode || QDELETED(src) || !operable())
+			return
+		if (!CanDefaultInteract(user))
+			to_chat(user, SPAN_WARNING("You're not able to do that to \the [src] right now."))
+			return
+		cook_mode = mode
+		to_chat(user, "The contents of \the [src] will now be [cook_modes[mode]["desc"]].")
+		interface_interact(user)
 
 /obj/machinery/cooker/attackby(obj/item/I, mob/user)
 	if (is_processing)
@@ -140,6 +159,8 @@
 	user.visible_message("\The [user] puts \the [I] into \the [src].")
 	I.forceMove(src)
 	cooking += I
+	if (winget(user, "cooker", "is-visible") == "true") // Refresh the interface if we have it open
+		interface_interact(user)
 
 /obj/machinery/cooker/Process()
 	if (!cooking.len)
@@ -155,8 +176,8 @@
 			cooking += cook_item(source[index])
 			--index
 		QDEL_NULL_LIST(source)
-		audible_message(SPAN_ITALIC("\The [src] lets out a happy ding."))
-		playsound(src, 'sound/machines/ding.ogg', 0.5)
+		audible_message(SPAN_NOTICE("\The [src] lets out a happy ding."))
+		playsound(src, 'sound/machines/ding.ogg', 50, FALSE)
 		threshold = 1
 	if (!burn_time)
 		empty()
@@ -255,7 +276,7 @@
 			"desc" = "made into jelly"
 		)
 	)
-	
+
 	machine_name = "modular cooker"
 	machine_desc = "Can prepare nearly any kind of food a certain way, such as making pies, cookies, or candy bars."
 

--- a/code/modules/client/preference_setup/_defines.dm
+++ b/code/modules/client/preference_setup/_defines.dm
@@ -14,8 +14,3 @@ if(!decls_by_name) \
 		decls_by_name[decl_instance.name] = decl_instance;\
 	}\
 }
-
-#define UIBUTTON(key, label, title) "[title ? title + ": " : ""]<a href='?src=\ref[src];[key]=1'>[label]</a>"
-
-#define UI_FONT_GOOD(X) "<font color='55cc55'>[X]</font>"
-#define UI_FONT_BAD(X) "<font color='cc5555'>[X]</font>"


### PR DESCRIPTION
#Описание
Добавляются интерфейсы устройств на кухне - гриля, фритюрницы, конфетницы, крупорушки ((господи, ну и слово))) (cereal maker) и плиты. Вместо всплывающих кнопок они будут иметь простой интерфейс с быстрым управлением и возможностью включения и выключения. Он включает все возможности текущего интерфейса, а также возможность видеть, активна ли плита, не глядя на ее спрайт.

Также унифицированы диапазоны для сообщений, исправлена ошибка, когда звук "ding" был беззвучным (0,5% громкости) и добавлен звуковой сигнал, который воспроизводится, когда плита включается.

🆑
rscadd: The chef's cookers (griddle, oven, etc.) have received a UI facelift.
bugfix: Cookers now properly play a ding when they finish cooking - previously the sound played at 0.5% volume.
/🆑