### PR TITLE
Mini_spasm event rebalance

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -188,6 +188,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Electrical Storm",		/datum/event/electrical_storm, 		0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Drone Revolution",				/datum/event/rogue_maint_drones/,	0,	list(ASSIGNMENT_ENGINEER = 10,ASSIGNMENT_MEDICAL = 10,ASSIGNMENT_SECURITY = 10)),
 		// new /datum/event_meta(EVENT_LEVEL_MAJOR, "Alien Infestation",				/datum/event/aliens, 				0,	list(ASSIGNMENT_SECURITY = 10)),  // INF  Broken random-event ~ SidVeld
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Psionic Signal",                  /datum/event/minispasm,             0,  list(ASSIGNMENT_MEDICAL = 10), 1),	
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Exoplanet Awakening",				/datum/event/exo_awakening,         0,  list(ASSIGNMENT_ANY = 45))
 	)
 

--- a/code/modules/psionics/events/mini_spasm.dm
+++ b/code/modules/psionics/events/mini_spasm.dm
@@ -49,7 +49,7 @@
 	else
 		to_chat(victim, SPAN_DANGER("An indescribable, brain-tearing sound hisses from [icon2html(source, victim)] \the [source], and you collapse in a seizure!"))
 		victim.seizure()
-			victim.adjustBrainLoss(rand(5,15))
+		victim.adjustBrainLoss(rand(5,15))
 	sleep(45)
 	victim.psi.check_latency_trigger(100, "a psionic scream", redactive = TRUE)
 

--- a/code/modules/psionics/events/mini_spasm.dm
+++ b/code/modules/psionics/events/mini_spasm.dm
@@ -49,14 +49,7 @@
 	else
 		to_chat(victim, SPAN_DANGER("An indescribable, brain-tearing sound hisses from [icon2html(source, victim)] \the [source], and you collapse in a seizure!"))
 		victim.seizure()
-		var/new_latencies = rand(2,4)
-		var/list/faculties = list(PSI_COERCION, PSI_REDACTION, PSI_ENERGISTICS, PSI_PSYCHOKINESIS)
-		for(var/i = 1 to new_latencies)
-			to_chat(victim, SPAN_DANGER("<font size = 3>[pick(psi_operancy_messages)]</font>"))
-			victim.adjustBrainLoss(rand(10,20))
-			victim.set_psi_rank(pick_n_take(faculties), 1)
-			sleep(30)
-		victim.psi.update()
+			victim.adjustBrainLoss(rand(5,15))
 	sleep(45)
 	victim.psi.check_latency_trigger(100, "a psionic scream", redactive = TRUE)
 


### PR DESCRIPTION
# Описание

Ребаланс и добавление в ротацию ивента псионического сигнала в соответствии с тем, как данный сигнал будет лучше работать в реалиях Сьерры.

## Основные изменения

* Добавлен ивент в ивент контейнер (опять)
* Убрана возможность стать псиоником для не-латентного члена экипажа из-за действия ивента
* Чуть подрезан брейндамаг от ивента
* Ивент всё также со 100% вероятностью раскрывает латентного псионика 
* Не-латенты всё ещё будут получать глухоту, слепоту и прочие прелести направленного пси-сигнала прямо в мозг


:cl:
tweak: tweaked a few things
balance: rebalanced something
/:cl:
