### PR TITLE
Гест пассы офисам капитана и ГП + патроны бармена

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -215,6 +215,11 @@
 	name = "box of stun shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/stun = 2)
 
+/obj/item/storage/box/ammo/bartender
+	name = "box of beanbag and illumination shells"
+	startswith = list(/obj/item/ammo_magazine/shotholder/beanbag = 2)
+	startswith = list(/obj/item/ammo_magazine/shotholder/flash = 2)
+
 /obj/item/storage/box/ammo/sniperammo
 	name = "box of sniper shells"
 	startswith = list(/obj/item/ammo_casing/shell = 7)

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -6511,6 +6511,10 @@
 	name = "heavy display case";
 	req_access = list("ACCESS_CAPTAIN")
 	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/captain/office_anteroom)
 "amm" = (
@@ -19312,9 +19316,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/storage/tech)
 "aIp" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -20
+/obj/machinery/computer/guestpass{
+	pixel_x = -20;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/captain/office_anteroom)
@@ -20910,6 +20914,10 @@
 /obj/machinery/camera/network/command{
 	c_tag = "Captain - Office";
 	dir = 6
+	},
+/obj/machinery/computer/guestpass{
+	pixel_x = -20;
+	dir = 4
 	},
 /turf/simulated/floor/carpet/red,
 /area/crew_quarters/heads/office/captain)

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -27163,6 +27163,10 @@
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/heads/office/hop)
 "aRc" = (
@@ -38614,11 +38618,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
 "hZS" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = -24
-	},
 /obj/machinery/camera/network/command{
 	c_tag = "Head of Personnel - Office";
 	dir = 1
@@ -38630,6 +38629,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	pixel_y = -23
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/hop)

--- a/maps/sierra/structures/closets/services.dm
+++ b/maps/sierra/structures/closets/services.dm
@@ -94,7 +94,7 @@
 		/obj/item/reagent_containers/food/drinks/shaker,
 		/obj/item/glass_jar,
 		/obj/item/book/manual/barman_recipes,
-		/obj/item/storage/box/ammo/beanbags,
+		/obj/item/storage/box/ammo/bartender,
 		/obj/item/clothing/under/rank/bartender,
 		/obj/item/clothing/gloves/thick,
 		/obj/item/clothing/gloves/white,


### PR DESCRIPTION
# Описание

* По просьбе администрации сделал то, что надо.

## Основные изменения

* У капитана теперь в офисе есть Guest Pass
* У главы персонала теперь в офисе есть Guest Pass
* Бармену дали на выбор и beangbag и flash патроны для дробовика.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: У ГП и капитана в распоряжении появилась возможность выдавать гостевые пропуски прямо в офисе.
balance: Бармен получил возможность выбирать какие патроны использовать, болевые или ослепляющие.
/:cl:
