### PR TITLE
Maptweak: removed CSO closet from Space

### DIFF
--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -40794,10 +40794,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
-"ogm" = (
-/obj/structure/closet/secure_closet/RD,
-/turf/space,
-/area/space)
 "oht" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -44191,7 +44187,7 @@ aaa
 aaa
 aaa
 aaa
-ogm
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
# Описание

Кто-то случайно решил оставить шкаф в космосе. Теперь его там не будет.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
maptweak: removed CSO closet from north-west of deck 1
/:cl:
