### PR TITLE
Фикс патронов бармена

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -217,8 +217,7 @@
 
 /obj/item/storage/box/ammo/bartender
 	name = "box of beanbag and illumination shells"
-	startswith = list(/obj/item/ammo_magazine/shotholder/beanbag = 2)
-	startswith = list(/obj/item/ammo_magazine/shotholder/flash = 2)
+	startswith = list(/obj/item/ammo_magazine/shotholder/beanbag = 2, /obj/item/ammo_magazine/shotholder/flash = 2)
 
 /obj/item/storage/box/ammo/sniperammo
 	name = "box of sniper shells"


### PR DESCRIPTION
# Описание

Когда в PR #342 делали коробку патронов бармену - сделали явную фигню, которая работает не так как задумано. Вместо 2 магазинов резины и 2 магазинов световых у бармена всего 2 магазина световых.

## Основные изменения

Фигня исправлена, у бармена все 4 магазина
