### PR TITLE
Fixed abscence of Psionic Signal in admin tools and event rotation

### DIFF
--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -49,6 +49,7 @@ var/list/event_last_fired = list()
 	if(minutes_passed >= 30) // Give engineers time to set up engine
 		possibleEvents[/datum/event/meteor_wave] = 10 * active_with_role["Engineer"]
 		possibleEvents[/datum/event/blob] = 10 * active_with_role["Engineer"]
+		possibleEvents[/datum/event/minispasm] = 10 * active_with_role["Medical"]
 
 	if(active_with_role["Medical"] > 0)
 		possibleEvents[/datum/event/radiation_storm] = active_with_role["Medical"] * 10


### PR DESCRIPTION
# Описание

* Ивент добавлен в event_dynamic.dm что должно по идее решить проблему с тем, что ивент не запускается на лайв сервере. 

:cl:
bugfix: fixed abscence of Psionic Signal in admin tools and event rotation

/:cl:
