### PR TITLE
Codex Augment is work NOW

### DIFF
--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -10,7 +10,7 @@
 	var/antag = get_antag_info()
 	if(!lore && !mechanics && !antag)
 		return FALSE
-		
+
 	var/datum/codex_entry/entry = new(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
 	return entry
 
@@ -27,5 +27,5 @@
 	. = ..()
 	var/datum/codex_entry/entry = SScodex.get_codex_entry(get_codex_value())
 	//This odd check v is done in case an item only has antag text but someone isn't an antag, in which case they shouldn't get the notice
-	if(entry && (entry.lore_text || entry.mechanics_text || (entry.antag_text && player_is_antag(user.mind))) && user.can_use_codex())
+	if(entry && (entry.lore_text || entry.mechanics_text || (entry.antag_text && player_is_antag(user.mind))) && user.can_use_codex(TRUE))
 		to_chat(user, "<span class='notice'>The codex has <b><a href='?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>relevant information</a></b> available.</span>")

--- a/code/modules/codex/codex_mob.dm
+++ b/code/modules/codex/codex_mob.dm
@@ -11,7 +11,7 @@
 	return TRUE
 
 /mob/living/carbon/human/can_use_codex()
-	return TRUE //has_implant(/obj/item/implant/codex, functioning = TRUE)
+	return has_codex_augment()
 
 /mob/living/carbon/human/get_codex_value()
 	return "[lowertext(species.name)] (species)"

--- a/code/modules/codex/codex_mob.dm
+++ b/code/modules/codex/codex_mob.dm
@@ -1,17 +1,20 @@
-/mob/proc/can_use_codex()
+/mob/proc/can_use_codex(var/examine_check = 0)
 	return FALSE
 
-/mob/new_player/can_use_codex()
+/mob/new_player/can_use_codex(var/examine_check = 0)
 	return TRUE
 
-/mob/living/silicon/can_use_codex()
+/mob/living/silicon/can_use_codex(var/examine_check = 0)
 	return TRUE
 
-/mob/observer/can_use_codex()
+/mob/observer/can_use_codex(var/examine_check = 0)
 	return TRUE
 
-/mob/living/carbon/human/can_use_codex()
-	return has_codex_augment()
+/mob/living/carbon/human/can_use_codex(var/examine_check = 0)
+	if (examine_check)
+		return has_codex_augment()
+	else
+		return TRUE
 
-/mob/living/carbon/human/get_codex_value()
+/mob/living/carbon/human/get_codex_value(var/examine_check = 0)
 	return "[lowertext(species.name)] (species)"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1618,8 +1618,7 @@ GLOBAL_LIST_EMPTY(compatable_genomes_owners)
 
 /mob/living/carbon/human/proc/has_codex_augment()
 	var/obj/item/organ/internal/A = internal_organs_by_name[BP_AUGMENT_HEAD]
-	var/obj/item/organ/internal/augment/fluff/head/codex_access/I = new /obj/item/organ/internal/augment/fluff/head/codex_access
-	if(A.name == I.name)
+	if(istype(A, /obj/item/organ/internal/augment/fluff/head/codex_access/))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1617,8 +1617,9 @@ GLOBAL_LIST_EMPTY(compatable_genomes_owners)
 	return 0
 
 /mob/living/carbon/human/proc/has_codex_augment()
-	var/obj/item/organ/internal/A = internal_organs_by_name["head augment"]
-	if(A.name == "\improper Codex access chip")
+	var/obj/item/organ/internal/A = internal_organs_by_name[BP_AUGMENT_HEAD]
+	var/obj/item/organ/internal/augment/fluff/head/codex_access/I = new /obj/item/organ/internal/augment/fluff/head/codex_access
+	if(A.name == I.name)
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1616,6 +1616,12 @@ GLOBAL_LIST_EMPTY(compatable_genomes_owners)
 			return 1
 	return 0
 
+/mob/living/carbon/human/proc/has_codex_augment()
+	var/obj/item/organ/internal/A = internal_organs_by_name["head augment"]
+	if(A.name == "\improper Codex access chip")
+		return TRUE
+	return FALSE
+
 /mob/living/carbon/human/slip(var/slipped_on, stun_duration=8)
 	if((species.check_no_slip(src)) || (shoes && (shoes.item_flags & ITEM_FLAG_NOSLIP)))
 		return 0


### PR DESCRIPTION
# Описание

* Починка имплант кодекса так, чтобы кнопка "relevant information", открывающая кодекс, работает теперь только у тех, у кого есть этот флафф аугмент кодеса. Судя по закомментированному коду у импланта - так и планировалось изначально. Оживляем фичу.

## Основные изменения

* Если ты /mob/living/carbon/human/, то теперь для работы кодекса тебе надо в Личных вещах взять себе "Codex access chip"

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: Make "Codex access chip" Great Again
balance: Кодекс теперь доступен только синтетам, обсервам и другим расам с установленным аугментом "Codex access chip"
/:cl:
