### PR TITLE
Feat: Уточнение зоны уничтожения ламп кнопками

### DIFF
--- a/code/modules/admin/secrets/fun_secrets/break_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/break_all_lights.dm
@@ -3,5 +3,27 @@
 
 /datum/admin_secret_item/fun_secret/break_all_lights/execute(var/mob/user)
 	. = ..()
-	if(.)
-		lightsout(0,0)
+	if(!.)
+		return
+
+	var choise = input("Which lights to break?") in list("My area", "My Z-Level", "Station", "All lights")
+	switch(choise)
+		if ("My area")
+			var/area/usr_area = get_area(user)
+			if (!usr_area) return to_chat(user, SPAN_DANGER("Invalid area!"))
+			for (var/obj/machinery/power/apc/apc in usr_area)
+				apc.overload_lighting()
+
+		if ("My Z-Level")
+			var/user_z = get_z(user)
+			if (!user_z) return to_chat(user, SPAN_DANGER("Invalid Z-Level!"))
+			for (var/obj/machinery/power/apc/apc in SSmachines.machinery)
+				if (apc.z == user_z) apc.overload_lighting()
+
+		if ("Station")
+			for (var/obj/machinery/power/apc/apc in SSmachines.machinery)
+				if (apc.z in GLOB.using_map.station_levels)
+					apc.overload_lighting()
+
+		if ("All lights")
+			lightsout(0, 0)

--- a/code/modules/admin/secrets/fun_secrets/break_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/break_all_lights.dm
@@ -6,7 +6,7 @@
 	if(!.)
 		return
 
-	var choise = input("Which lights to break?") in list("My area", "My Z-Level", "Station", "All lights")
+	var/choise = input("Which lights to break?") in list("My area", "My Z-Level", "Station", "All lights")
 	switch(choise)
 		if ("My area")
 			var/area/usr_area = get_area(user)

--- a/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
@@ -6,7 +6,7 @@
 	if(!.)
 		return
 
-	var choise = input("Which lights to fix?") in list("My area", "My Z-Level", "Station", "All lights")
+	var/choise = input("Which lights to fix?") in list("My area", "My Z-Level", "Station", "All lights")
 	switch(choise)
 		if ("My area")
 			var/area/usr_area = get_area(user)

--- a/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
@@ -6,5 +6,25 @@
 	if(!.)
 		return
 
-	for(var/obj/machinery/light/L in world)
-		L.fix()
+	var choise = input("Which lights to fix?") in list("My area", "My Z-Level", "Station", "All lights")
+	switch(choise)
+		if ("My area")
+			var/area/usr_area = get_area(user)
+			if (!usr_area) return to_chat(user, SPAN_DANGER("Invalid area!"))
+			for (var/obj/machinery/light/light in usr_area)
+				light.fix()
+
+		if ("My Z-Level")
+			var/user_z = get_z(user)
+			if (!user_z) return to_chat(user, SPAN_DANGER("Invalid Z-Level!"))
+			for (var/obj/machinery/light/light in SSmachines.machinery)
+				if (light.z == user_z) light.fix()
+
+		if ("Station")
+			for (var/obj/machinery/light/light in SSmachines.machinery)
+				if (light.z in GLOB.using_map.station_levels)
+					light.fix()
+
+		if ("All lights")
+			for (var/obj/machinery/light/light in SSmachines.machinery)
+				light.fix()


### PR DESCRIPTION
Secrets -> Fun Secrets -> Break All Lights и Fix All Lights дают выбор зоны для ломания/восстановления ламп:
* Только в Area нахождения Mob'a
* Только на Z-уровне нахождения Mob'a
* Только на Z-уровнях активной карты
* Абсолютно все лампы