### PR TITLE
Фикс кнопки в хранилище медбея

### DIFF
--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -5252,13 +5252,6 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/obj/machinery/button/blast_door{
-	id_tag = "infirmaryquar";
-	name = "Infirmary Quar Lockdown";
-	pixel_x = -5;
-	pixel_y = -20;
-	req_access = list("ACCESS_MEDICAL")
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/maintenance_equipstorage)
 "ajO" = (
@@ -29051,7 +29044,8 @@
 "baf" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -21
+	pixel_y = -21;
+	pixel_x = -8
 	},
 /obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -29061,6 +29055,14 @@
 	},
 /obj/effect/floor_decal/corner/pink/bordercorner2{
 	dir = 9
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "infirmaryquar";
+	name = "Infirmary Quar Lockdown";
+	pixel_x = 6;
+	pixel_y = -21;
+	req_access = list("ACCESS_MEDICAL");
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/maintenance_equipstorage)


### PR DESCRIPTION
# Описание

Больше нет желтого огонька на полу медбея на первой палубе.

## Основные изменения

* Желтый огонёк больше не мозолит глаза, кнопка переставлена.

## Скриншоты


| Было                   | Стало                  |
| ---------------------- | ---------------------- |
| ![image](https://user-images.githubusercontent.com/56347411/193465427-5299b535-e26b-4fa1-9d41-07bb7428d7bf.png) | ![image](https://user-images.githubusercontent.com/56347411/193465432-ee39eb1e-7db7-40e0-bb86-22d3bcf1c2ac.png) |
| ![image](https://user-images.githubusercontent.com/56347411/193465439-81796fbb-009f-4fe8-9b87-1a9ded271207.png) | ![image](https://user-images.githubusercontent.com/56347411/193465445-3aca1b8e-fd79-4173-a4f5-c930ad8a194b.png) |

:cl:
maptweak: yellow button was moved a little bit
/:cl:
