### PR TITLE
Фикс камер и освещения в кафетерии.

### DIFF
--- a/maps/sierra/areas/sierra1.dm
+++ b/maps/sierra/areas/sierra1.dm
@@ -186,6 +186,9 @@
 	icon_state = "janitor"
 	req_access = list(access_janitor)
 
+/area/hydroponics/third_deck_storage
+	name = "Third Deck - Service - Hydroponics Storage"
+
 /* SECURITY AREAS
  *
  */

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -978,7 +978,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "cc" = (
 /obj/machinery/artifact_harvester,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -2436,7 +2436,7 @@
 	},
 /obj/structure/closet/crate/hydroponics/beekeeping,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "eB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2451,7 +2451,7 @@
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "eD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -4616,7 +4616,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "hY" = (
 /obj/effect/paint/nt_white,
 /obj/effect/paint_stripe/nt_red,
@@ -11617,7 +11617,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "rQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12169,7 +12169,7 @@
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "sD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12459,7 +12459,7 @@
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "te" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external/escapepod{
@@ -13056,7 +13056,7 @@
 	},
 /obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "ud" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -13378,7 +13378,7 @@
 	},
 /obj/machinery/seed_storage/garden,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "uH" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/effect/paint_stripe/yellow,
@@ -14633,7 +14633,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "wF" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "sensor_shutters"
@@ -19685,7 +19685,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "Fb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21029,7 +21029,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "Hh" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/firedoor,
@@ -23223,7 +23223,7 @@
 	},
 /obj/structure/closet/secure_closet/hydroponics_sierra,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "KC" = (
 /obj/structure/hygiene/shower{
 	dir = 4;
@@ -23911,7 +23911,7 @@
 /area/quartermaster/hangar)
 "LO" = (
 /turf/simulated/wall/prepainted,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "LP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25265,7 +25265,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "NY" = (
 /obj/structure/closet/emcloset{
 	anchored = 1;
@@ -28299,7 +28299,7 @@
 /area/shuttle/petrov/gas)
 "Tj" = (
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "Tk" = (
 /obj/machinery/door/blast/regular/escape_pod{
 	id_tag = "escape_pod_4"
@@ -29840,7 +29840,7 @@
 	},
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "WB" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
@@ -30002,7 +30002,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "WS" = (
 /obj/machinery/sleeper/survival_pod{
 	dir = 1
@@ -30079,7 +30079,7 @@
 	},
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "Xa" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -31297,7 +31297,7 @@
 /area/exploration_shuttle/power)
 "ZH" = (
 /turf/simulated/wall/r_wall/hull,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "ZI" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/thirddeck/forestarboard)
@@ -31403,7 +31403,7 @@
 	},
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled,
-/area/hydroponics/storage)
+/area/hydroponics/third_deck_storage)
 "ZV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
@@ -49299,7 +49299,7 @@ Fa
 LO
 LO
 LO
-LO
+XD
 VU
 if
 tw
@@ -49501,7 +49501,7 @@ Hg
 eA
 KB
 WA
-LO
+XD
 YW
 if
 iw
@@ -49703,7 +49703,7 @@ Tj
 Tj
 eC
 uc
-LO
+XD
 eP
 vI
 tw
@@ -49905,7 +49905,7 @@ Tj
 Tj
 NX
 LO
-LO
+XD
 gZ
 tT
 tw
@@ -50106,7 +50106,7 @@ wE
 td
 cb
 sC
-LO
+XD
 bF
 hb
 gi
@@ -50308,7 +50308,7 @@ rP
 hX
 WZ
 LO
-LO
+XD
 UW
 ht
 dp

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -5815,10 +5815,6 @@
 	name = "Bar Shutters"
 	},
 /obj/structure/table/steel_reinforced,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Bartenders'";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/bar)
 "akS" = (
@@ -8894,6 +8890,9 @@
 "aqh" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/machinery/recharger,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet/orange,
 /area/crew_quarters/cafe)
 "aqi" = (
@@ -13360,7 +13359,7 @@
 	id_tag = "hydro<-bar";
 	name = "Hydroponics Shutters";
 	pixel_x = 24;
-	pixel_y = 6;
+	pixel_y = 1;
 	req_access = list("ACCESS_BAR")
 	},
 /obj/machinery/button/blast_door{
@@ -13368,12 +13367,16 @@
 	id_tag = "bar<-cafe";
 	name = "Bar Shutters";
 	pixel_x = 24;
-	pixel_y = -6;
+	pixel_y = -10;
 	req_access = list("ACCESS_BAR")
 	},
 /obj/machinery/jukebox/old,
 /obj/random/date_based/christmas/xmaslights,
 /obj/machinery/light/led/small,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck - Bartenders'";
+	dir = 8
+	},
 /turf/simulated/floor/wood/ebony,
 /area/crew_quarters/bar)
 "aya" = (
@@ -35845,7 +35848,7 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -23;
-	pixel_y = 12
+	pixel_y = 10
 	},
 /obj/machinery/disposal/small{
 	dir = 4

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -34482,7 +34482,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/game_room)
 "dSv" = (
-/obj/random/date_based/christmas/tree,
+/obj/random/date_based/christmas/tree{
+	pixel_x = 16
+	},
 /turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/lounge_big)
 "dUI" = (

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -2002,10 +2002,6 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
-/obj/structure/hygiene/sink{
-	dir = 4;
-	pixel_x = 22
-	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "aed" = (

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -7285,6 +7285,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/random/date_based/christmas/tree{
+	pixel_x = 16;
+	pixel_y = 16
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/cafe)
 "anD" = (

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -5685,11 +5685,6 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Cafe - Food Display";
-	dir = 4;
-	pixel_y = 18
-	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/cafe)
 "akE" = (
@@ -5820,6 +5815,10 @@
 	name = "Bar Shutters"
 	},
 /obj/structure/table/steel_reinforced,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck - Bartenders'";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/bar)
 "akS" = (
@@ -37864,6 +37863,9 @@
 	pixel_y = 2
 	},
 /obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Cafe - Food Display"
+	},
 /turf/simulated/floor/wood/yew,
 /area/crew_quarters/cafe)
 "nVM" = (
@@ -38994,10 +38996,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"qMf" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/prepainted,
-/area/maintenance/seconddeck/emergency)
 "qNk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -39633,23 +39631,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
-"sst" = (
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id_tag = "bar<-cafe";
-	name = "Bar Shutters"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Bartenders'";
-	dir = 4;
-	pixel_y = 19
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/crew_quarters/bar)
 "str" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -41118,12 +41099,11 @@
 	dir = 4;
 	id = "cap_windows";
 	pixel_x = -21;
-	pixel_y = -1
+	pixel_y = 5
 	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Cafe - Piano";
-	dir = 4;
-	pixel_y = 18
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/cafe)
@@ -41599,7 +41579,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler,
@@ -58156,7 +58136,7 @@ wAG
 agR
 alp
 hOm
-sst
+avt
 aln
 aVY
 oFT
@@ -59368,7 +59348,7 @@ wQu
 wQu
 wQu
 wQu
-qMf
+wQu
 aqh
 pnB
 vzV

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -5686,8 +5686,9 @@
 	dir = 8
 	},
 /obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Grove Branch";
-	dir = 4
+	c_tag = "Cafe - Food Display";
+	dir = 4;
+	pixel_y = 18
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/cafe)
@@ -5817,10 +5818,6 @@
 	dir = 2;
 	id_tag = "bar<-cafe";
 	name = "Bar Shutters"
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Bartenders'";
-	dir = 8
 	},
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -38161,7 +38158,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/nano)
 "oIG" = (
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 1
 	},
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -39636,6 +39633,23 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
+"sst" = (
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "bar<-cafe";
+	name = "Bar Shutters"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck - Bartenders'";
+	dir = 4;
+	pixel_y = 19
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/bar)
 "str" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -41103,8 +41117,13 @@
 /obj/machinery/button/windowtint{
 	dir = 4;
 	id = "cap_windows";
-	pixel_x = -23;
-	pixel_y = 6
+	pixel_x = -21;
+	pixel_y = -1
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Cafe - Piano";
+	dir = 4;
+	pixel_y = 18
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/cafe)
@@ -58137,7 +58156,7 @@ wAG
 agR
 alp
 hOm
-avt
+sst
 aln
 aVY
 oFT


### PR DESCRIPTION
# Описание

* До этого камеры имели поломанное название в кафетерии, но только не сегодня.
* Сегодня мы пофиксили название камер, их расположение на стенах и даже...
* ... добавили одну новую, что бы не было темных пятен для ИИ, когда тот смотрит на бар.
* И да, мы заменили одну лампу на лампу помощнее, что бы не было буквально темного пятна посреди комнаты.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
maptweak: Фикс ламп и освещения в кафетерии
/:cl:
