### PR TITLE
Adds LAR to ERT-Armory

### DIFF
--- a/maps/antag_spawn/ert/ert_base_inf.dmm
+++ b/maps/antag_spawn/ert/ert_base_inf.dmm
@@ -3636,8 +3636,9 @@
 /area/map_template/rescue_base/office)
 "Dd" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser/assault,
+/obj/item/gun/energy/laser/assault,
+/obj/item/gun/energy/laser/assault,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "vault"


### PR DESCRIPTION
# Описание

Добавляется LAR в оружейную ЕРТ по указанию свыше
![image](https://user-images.githubusercontent.com/87862013/194638179-02f830ef-e9ed-4eb0-8ed0-bf25266c5574.png)

:cl:
maptweak: added LAR to ERT-armory
/:cl:
