### PR TITLE
Hostile mobs don't break the server for now 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -18,7 +18,6 @@
 	natural_weapon = /obj/item/melee/energy/sword/pirate/activated
 	unsuitable_atmos_damage = 15
 	var/corpse = /obj/effect/landmark/corpse/pirate
-	var/weapon1 = /obj/item/melee/energy/sword/pirate
 
 	faction = "pirate"
 
@@ -34,7 +33,6 @@
 	rapid = 1
 	projectiletype = /obj/item/projectile/beam
 	corpse = /obj/effect/landmark/corpse/pirate/ranged
-	weapon1 = /obj/item/gun/energy/laser
 
 	ai_holder_type = /datum/ai_holder/simple_animal/pirate/ranged
 
@@ -42,8 +40,6 @@
 	..(gibbed, deathmessage, show_dead_message)
 	if(corpse)
 		new corpse (src.loc)
-	if(weapon1)
-		new weapon1 (src.loc)
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -17,8 +17,6 @@
 	can_escape = TRUE
 	a_intent = I_HURT
 	var/corpse = /obj/effect/landmark/corpse/syndicate
-	var/weapon1
-	var/weapon2
 	unsuitable_atmos_damage = 15
 	environment_smash = 1
 	faction = "syndicate"
@@ -28,10 +26,6 @@
 	..(gibbed, deathmessage, show_dead_message)
 	if(corpse)
 		new corpse (src.loc)
-	if(weapon1)
-		new weapon1 (src.loc)
-	if(weapon2)
-		new weapon2 (src.loc)
 	qdel(src)
 	return
 
@@ -41,8 +35,6 @@
 	icon_state = "syndicatemelee"
 	icon_living = "syndicatemelee"
 	natural_weapon = /obj/item/melee/energy/sword/red/activated
-	weapon1 = /obj/item/melee/energy/sword/red/activated
-	weapon2 = /obj/item/shield/energy
 	status_flags = 0
 
 /mob/living/simple_animal/hostile/syndicate/melee/attackby(var/obj/item/O as obj, var/mob/user as mob)
@@ -89,7 +81,6 @@
 	projectilesound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	projectiletype = /obj/item/projectile/bullet/pistol
 
-	weapon1 = /obj/item/gun/projectile/automatic/merc_smg
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space
 	icon_state = "syndicaterangedpsace"


### PR DESCRIPTION

:cl:
bugfix: Враждебные мобы больше не дропают гильзы от снарядов, роняя сервер.
tweak: Мобы синдиката, русские и пираты больше не дропают лут.
/:cl:
From: 
https://github.com/BoHBranch/BoH-Bay/pull/1007