### PR TITLE
Fix: Стеклянные ведро и тряпка

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2923,6 +2923,7 @@
 #include "code\modules\reagents\reagent_containers\food.dm"
 #include "code\modules\reagents\reagent_containers\glass.dm"
 #include "code\modules\reagents\reagent_containers\hypospray.dm"
+#include "code\modules\reagents\reagent_containers\misc.dm"
 #include "code\modules\reagents\reagent_containers\pill.dm"
 #include "code\modules\reagents\reagent_containers\spray.dm"
 #include "code\modules\reagents\reagent_containers\syringes.dm"

--- a/code/datums/outfits/tournament.dm
+++ b/code/datums/outfits/tournament.dm
@@ -38,13 +38,13 @@
 	uniform = /obj/item/clothing/under/rank/janitor
 	back = /obj/item/storage/backpack
 	r_hand = /obj/item/mop
-	l_hand = /obj/item/reagent_containers/glass/bucket
+	l_hand = /obj/item/reagent_containers/misc/bucket
 	l_pocket = /obj/item/grenade/chem_grenade/cleaner
 	r_pocket = /obj/item/grenade/chem_grenade/cleaner
 	backpack_contents = list(/obj/item/stack/tile/floor = 6)
 
 /decl/hierarchy/outfit/tournament_gear/janitor/post_equip(var/mob/living/carbon/human/H)
 	..()
-	var/obj/item/reagent_containers/glass/bucket/bucket = locate(/obj/item/reagent_containers/glass/bucket) in H
+	var/obj/item/reagent_containers/misc/bucket/bucket = locate(/obj/item/reagent_containers/misc/bucket) in H
 	if(bucket)
 		bucket.reagents.add_reagent(/datum/reagent/water, 70)

--- a/code/datums/supplypacks/custodial.dm
+++ b/code/datums/supplypacks/custodial.dm
@@ -3,14 +3,14 @@
 
 /decl/hierarchy/supply_pack/custodial/janitor
 	name = "Gear - Janitorial supplies"
-	contains = list(/obj/item/reagent_containers/glass/bucket,
+	contains = list(/obj/item/reagent_containers/misc/bucket,
 					/obj/item/mop,
 					/obj/item/caution = 4,
 					/obj/item/storage/bag/trash,
 					/obj/item/device/lightreplacer,
 					/obj/item/reagent_containers/spray/cleaner,
 					/obj/item/storage/box/lights/mixed,
-					/obj/item/reagent_containers/glass/rag,
+					/obj/item/reagent_containers/misc/rag,
 					/obj/item/grenade/chem_grenade/cleaner = 3,
 					/obj/structure/mopbucket)
 	cost = 20
@@ -35,8 +35,8 @@
 	contains = list(/obj/item/mop,
 					/obj/item/grenade/chem_grenade/cleaner = 3,
 					/obj/item/storage/box/detergent = 3,
-					/obj/item/reagent_containers/glass/bucket,
-					/obj/item/reagent_containers/glass/rag,
+					/obj/item/reagent_containers/misc/bucket,
+					/obj/item/reagent_containers/misc/rag,
 					/obj/item/reagent_containers/spray/cleaner = 2,
 					/obj/item/soap)
 	cost = 10

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -95,7 +95,7 @@
 		return
 
 	else if(dirtiness == 100) // The microwave is all dirty, so it can't be used!
-		var/has_rag = istype(O, /obj/item/reagent_containers/glass/rag)
+		var/has_rag = istype(O, /obj/item/reagent_containers/misc/rag)
 		var/has_cleaner = O.reagents != null && O.reagents.has_reagent(/datum/reagent/space_cleaner, 5)
 
 		// If they're trying to clean it, let them

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -569,7 +569,7 @@ obj/random/closet //A couple of random closets to spice up maint
 
 /obj/random/soap/spawn_choices()
 	return list(/obj/item/soap = 12,
-				/obj/item/reagent_containers/glass/rag = 2,
+				/obj/item/reagent_containers/misc/rag = 2,
 				/obj/item/reagent_containers/spray/cleaner = 2,
 				/obj/item/grenade/chem_grenade/cleaner = 1)
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -24,7 +24,7 @@ LINEN BINS
 		if(do_after(user, 50, src))
 			to_chat(user, "<span class='notice'>You cut \the [src] into pieces!</span>")
 			for(var/i in 1 to rand(2,5))
-				new /obj/item/reagent_containers/glass/rag(get_turf(src))
+				new /obj/item/reagent_containers/misc/rag(get_turf(src))
 			qdel(src)
 		return
 	..()

--- a/code/modules/ascent/ascent_doodads.dm
+++ b/code/modules/ascent/ascent_doodads.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/ascent_doodads.dmi'
 	item_state = "advmop"
 
-/obj/item/reagent_containers/glass/bucket/ascent
+/obj/item/reagent_containers/misc/bucket/ascent
 	name = "portable liquid cleaning agent carrier"
 	desc = "An alien container of some sort."
 	icon = 'icons/obj/ascent_doodads.dmi'

--- a/code/modules/crafting/crafting_farmbot.dm
+++ b/code/modules/crafting/crafting_farmbot.dm
@@ -22,7 +22,7 @@
 
 /decl/crafting_stage/farmbot_bucket
 	progress_message = "You attach the bucket to the assembly."
-	completion_trigger_type = /obj/item/reagent_containers/glass/bucket
+	completion_trigger_type = /obj/item/reagent_containers/misc/bucket
 	next_stages = list(/decl/crafting_stage/farmbot_minihoe)
 	item_icon_state = "farmbot_1"
 

--- a/code/modules/crafting/crafting_janibot.dm
+++ b/code/modules/crafting/crafting_janibot.dm
@@ -1,5 +1,5 @@
 /decl/crafting_stage/proximity/janibot
-	begins_with_object_type = /obj/item/reagent_containers/glass/bucket
+	begins_with_object_type = /obj/item/reagent_containers/misc/bucket
 	progress_message = "You put the proximity sensor into the bucket."
 	item_icon_state = "janibot_1"
 	next_stages = list(/decl/crafting_stage/robot_arms/janibot)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -13,7 +13,7 @@
 /obj/item/clothing/shoes/
 	var/track_blood = 0
 
-/obj/item/reagent_containers/glass/rag
+/obj/item/reagent_containers/misc/rag
 	name = "rag"
 	desc = "For cleaning up messes, you suppose."
 	w_class = ITEM_SIZE_TINY
@@ -22,7 +22,6 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = "5"
 	volume = 10
-	can_be_placed_into = null
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	unacidable = FALSE
@@ -30,22 +29,31 @@
 	var/on_fire = 0
 	var/burn_time = 20 //if the rag burns for too long it turns to ashes
 
-/obj/item/reagent_containers/glass/rag/New()
+/obj/item/reagent_containers/misc/rag/New()
 	..()
 	update_name()
 
-/obj/item/reagent_containers/glass/rag/Destroy()
+/obj/item/reagent_containers/misc/rag/Destroy()
 	STOP_PROCESSING(SSobj, src) //so we don't continue turning to ash while gc'd
 	. = ..()
 
-/obj/item/reagent_containers/glass/rag/attack_self(mob/user as mob)
+/obj/item/reagent_containers/misc/rag/display_reagent_volume(mob/user)
+	if(!reagents || reagents.total_volume == 0)
+		to_chat(user, "<span class='notice'>It is dry.</span>")
+	else if(reagents.total_volume <= volume * 0.5)
+		to_chat(user, "<span class='notice'>It is moist.</span>")
+	else
+		to_chat(user, "<span class='notice'>It is wet.</span>")
+
+
+/obj/item/reagent_containers/misc/rag/attack_self(mob/user as mob)
 	if(on_fire && user.unEquip(src))
 		user.visible_message("<span class='warning'>\The [user] stamps out [src].</span>", "<span class='warning'>You stamp out [src].</span>")
 		extinguish()
 	else
 		remove_contents(user)
 
-/obj/item/reagent_containers/glass/rag/attackby(obj/item/W, mob/user)
+/obj/item/reagent_containers/misc/rag/attackby(obj/item/W, mob/user)
 	if(!on_fire && isflamesource(W))
 		ignite()
 		if(on_fire)
@@ -59,7 +67,7 @@
 	. = ..()
 	update_name()
 
-/obj/item/reagent_containers/glass/rag/proc/update_name()
+/obj/item/reagent_containers/misc/rag/proc/update_name()
 	if(on_fire)
 		SetName("burning [initial(name)]")
 	else if(reagents.total_volume)
@@ -67,7 +75,7 @@
 	else
 		SetName("dry [initial(name)]")
 
-/obj/item/reagent_containers/glass/rag/on_update_icon()
+/obj/item/reagent_containers/misc/rag/on_update_icon()
 	if(on_fire)
 		icon_state = "raglit"
 	else
@@ -77,7 +85,7 @@
 	if(istype(B))
 		B.update_icon()
 
-/obj/item/reagent_containers/glass/rag/proc/remove_contents(mob/user, atom/trans_dest = null)
+/obj/item/reagent_containers/misc/rag/proc/remove_contents(mob/user, atom/trans_dest = null)
 	if(!trans_dest && !user.loc)
 		return
 
@@ -93,7 +101,7 @@
 			user.visible_message("<span class='danger'>\The [user] wrings out [src] over [target_text].</span>", "<span class='notice'>You finish to wringing out [src].</span>")
 			update_name()
 
-/obj/item/reagent_containers/glass/rag/proc/wipe_down(atom/A, mob/user)
+/obj/item/reagent_containers/misc/rag/proc/wipe_down(atom/A, mob/user)
 	if(!reagents.total_volume)
 		to_chat(user, "<span class='warning'>The [initial(name)] is dry!</span>")
 	else
@@ -108,7 +116,7 @@
 			else
 				A.clean_blood()
 
-/obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
+/obj/item/reagent_containers/misc/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
 	if(isliving(target))
 		var/mob/living/M = target
 		if(on_fire)
@@ -158,7 +166,7 @@
 
 	return ..()
 
-/obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
+/obj/item/reagent_containers/misc/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)
 		return
 
@@ -179,7 +187,7 @@
 			wipe_down(A, user)
 		return
 
-/obj/item/reagent_containers/glass/rag/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+/obj/item/reagent_containers/misc/rag/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature >= 50 + T0C)
 		ignite()
 	if(exposed_temperature >= 900 + T0C)
@@ -188,11 +196,11 @@
 
 //rag must have a minimum of 2 units welder fuel and at least 80% of the reagents must be welder fuel.
 //maybe generalize flammable reagents someday
-/obj/item/reagent_containers/glass/rag/proc/can_ignite()
+/obj/item/reagent_containers/misc/rag/proc/can_ignite()
 	var/fuel = reagents.get_reagent_amount(/datum/reagent/fuel)
 	return (fuel >= 2 && fuel >= reagents.total_volume*0.8)
 
-/obj/item/reagent_containers/glass/rag/proc/ignite()
+/obj/item/reagent_containers/misc/rag/proc/ignite()
 	if(on_fire)
 		return
 	if(!can_ignite())
@@ -213,7 +221,7 @@
 	update_name()
 	update_icon()
 
-/obj/item/reagent_containers/glass/rag/proc/extinguish()
+/obj/item/reagent_containers/misc/rag/proc/extinguish()
 	STOP_PROCESSING(SSobj, src)
 	set_light(0)
 	on_fire = 0
@@ -227,7 +235,7 @@
 	update_name()
 	update_icon()
 
-/obj/item/reagent_containers/glass/rag/Process()
+/obj/item/reagent_containers/misc/rag/Process()
 	if(!can_ignite())
 		visible_message("<span class='warning'>\The [src] burns out.</span>")
 		extinguish()

--- a/code/modules/fabrication/designs/general/designs_general.dm
+++ b/code/modules/fabrication/designs/general/designs_general.dm
@@ -1,5 +1,5 @@
 /datum/fabricator_recipe/bucket
-	path = /obj/item/reagent_containers/glass/bucket
+	path = /obj/item/reagent_containers/misc/bucket
 
 /datum/fabricator_recipe/flashlight
 	path = /obj/item/device/flashlight

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -14,7 +14,7 @@ var/list/worths = list(
 					/obj/item/reagent_containers/food/snacks/slice = -3,
 					/obj/item/reagent_containers/food/drinks/bottle = -11,
 					/obj/item/reagent_containers/food/drinks = -8,
-					/obj/item/reagent_containers/glass/rag = -5,
+					/obj/item/reagent_containers/misc/rag = -5,
 					/obj/item/reagent_containers/glass = -60,
 					/obj/item/reagent_containers = -1,
 //GUNS,

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -89,7 +89,7 @@
 	visible_message("<span class='danger'>[src] blows apart!</span>")
 	var/turf/Tsec = get_turf(src)
 
-	new /obj/item/reagent_containers/glass/bucket(Tsec)
+	new /obj/item/reagent_containers/misc/bucket(Tsec)
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 	if(prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -229,7 +229,7 @@
 	var/turf/Tsec = get_turf(src)
 
 	new /obj/item/material/minihoe(Tsec)
-	new /obj/item/reagent_containers/glass/bucket(Tsec)
+	new /obj/item/reagent_containers/misc/bucket(Tsec)
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 	new /obj/item/device/scanner/plant(Tsec)
 

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
@@ -15,7 +15,7 @@
 		/obj/item/wirecutters/clippers,
 		/obj/item/material/minihoe/unbreakable,
 		/obj/item/material/hatchet/unbreakable,
-		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/reagent_containers/misc/bucket,
 		/obj/item/scalpel/laser1,
 		/obj/item/circular_saw,
 		/obj/item/extinguisher,

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -24,7 +24,7 @@
 	equipment = list(
 		/obj/item/device/flash,
 		/obj/item/gripper/service,
-		/obj/item/reagent_containers/glass/bucket,
+		/obj/item/reagent_containers/misc/bucket,
 		/obj/item/material/minihoe,
 		/obj/item/material/hatchet,
 		/obj/item/device/scanner/plant,

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -10,7 +10,7 @@
 	var/smash_duration = 5 //Directly relates to the 'weaken' duration. Lowered by armor (i.e. helmets)
 	var/isGlass = TRUE //Whether the 'bottle' is made of glass or not so that milk cartons don't shatter when someone gets hit by it
 
-	var/obj/item/reagent_containers/glass/rag/rag = null
+	var/obj/item/reagent_containers/misc/rag/rag = null
 	var/rag_underlay = "rag"
 
 /obj/item/reagent_containers/food/drinks/bottle/Initialize()
@@ -79,7 +79,7 @@
 	return B
 
 /obj/item/reagent_containers/food/drinks/bottle/attackby(obj/item/W, mob/user)
-	if(!rag && istype(W, /obj/item/reagent_containers/glass/rag))
+	if(!rag && istype(W, /obj/item/reagent_containers/misc/rag))
 		insert_rag(W, user)
 		return
 	if(rag && isflamesource(W))
@@ -93,7 +93,7 @@
 	else
 		..()
 
-/obj/item/reagent_containers/food/drinks/bottle/proc/insert_rag(obj/item/reagent_containers/glass/rag/R, mob/user)
+/obj/item/reagent_containers/food/drinks/bottle/proc/insert_rag(obj/item/reagent_containers/misc/rag/R, mob/user)
 	if(!isGlass || rag)
 		return
 	if(user.unEquip(R))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -279,51 +279,6 @@
 		reagents.add_reagent(/datum/reagent/acid, 60)
 		update_icon()
 
-/obj/item/reagent_containers/glass/bucket
-	name = "bucket"
-	desc = "It's a bucket."
-	icon = 'icons/obj/janitor.dmi'
-	icon_state = "bucket"
-	item_state = "bucket"
-	center_of_mass = "x=16;y=9"
-	matter = list(MATERIAL_PLASTIC = 280)
-	w_class = ITEM_SIZE_NORMAL
-	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = "10;20;30;60;120;150;180"
-	volume = 180
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	unacidable = FALSE
-
-/obj/item/reagent_containers/glass/bucket/wood
-	name = "bucket"
-	desc = "It's a wooden bucket. How rustic."
-	icon_state = "wbucket"
-	item_state = "wbucket"
-	matter = list(MATERIAL_WOOD = 280)
-	volume = 200
-
-/obj/item/reagent_containers/glass/bucket/attackby(var/obj/D, mob/user as mob)
-	if(istype(D, /obj/item/mop))
-		if(reagents.total_volume < 1)
-			to_chat(user, "<span class='warning'>\The [src] is empty!</span>")
-		else
-			reagents.trans_to_obj(D, 5)
-			to_chat(user, "<span class='notice'>You wet \the [D] in \the [src].</span>")
-			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		return
-	else
-		return ..()
-
-/obj/item/reagent_containers/glass/bucket/on_update_icon()
-	overlays.Cut()
-	if (!is_open_container())
-		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
-		overlays += lid
-	else if(reagents.total_volume && round((reagents.total_volume / volume) * 100) > 80)
-		var/image/filling = image('icons/obj/reagentfillings.dmi', src, "bucket")
-		filling.color = reagents.get_color()
-		overlays += filling
-
 /*
 /obj/item/reagent_containers/glass/blender_jug
 	name = "Blender Jug"

--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -1,0 +1,114 @@
+/obj/item/reagent_containers/misc
+	unacidable = FALSE
+	var/has_lid = FALSE
+
+/obj/item/reagent_containers/misc/examine(mob/user, distance)
+	. = ..()
+	if(distance > 2)
+		return
+
+	display_reagent_volume(user)
+
+/obj/item/reagent_containers/misc/proc/display_reagent_volume(mob/user)
+	if(!reagents || reagents.total_volume == 0)
+		to_chat(user, SPAN_NOTICE("\The [src] is empty!"))
+	else if (reagents.total_volume <= volume * 0.25)
+		to_chat(user, SPAN_NOTICE("\The [src] is almost empty!"))
+	else if (reagents.total_volume <= volume * 0.66)
+		to_chat(user, SPAN_NOTICE("\The [src] is half full!"))
+	else if (reagents.total_volume <= volume * 0.90)
+		to_chat(user, SPAN_NOTICE("\The [src] is almost full!"))
+	else
+		to_chat(user, SPAN_NOTICE("\The [src] is full!"))
+
+/obj/item/reagent_containers/misc/attack_self()
+	..()
+	if(is_open_container() && has_lid)
+		to_chat(usr, "<span class = 'notice'>You put the lid on \the [src].</span>")
+		atom_flags ^= ATOM_FLAG_OPEN_CONTAINER
+	else
+		to_chat(usr, "<span class = 'notice'>You take the lid off \the [src].</span>")
+		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
+	update_icon()
+
+/obj/item/reagent_containers/misc/attack(mob/M as mob, mob/user as mob, def_zone)
+	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
+		return	..()
+	if(standard_feed_mob(user, M))
+		return
+	return 0
+
+/obj/item/reagent_containers/misc/standard_feed_mob(var/mob/user, var/mob/target)
+	if(!is_open_container())
+		to_chat(user, "<span class='notice'>You need to open \the [src] first.</span>")
+		return 1
+	if(user.a_intent == I_HURT)
+		return 1
+	return ..()
+
+/obj/item/reagent_containers/misc/self_feed_message(var/mob/user)
+	to_chat(user, "<span class='notice'>You swallow a gulp from \the [src].</span>")
+	if(user.has_personal_goal(/datum/goal/achievement/specific_object/drink))
+		for(var/datum/reagent/R in reagents.reagent_list)
+			user.update_personal_goal(/datum/goal/achievement/specific_object/drink, R.type)
+
+/obj/item/reagent_containers/misc/throw_impact(atom/hit_atom)
+	if (QDELETED(src))
+		return
+	if (reagents.reagent_list.len > 0)
+		visible_message(
+			SPAN_DANGER("\The [src] spills all its contents!"),
+			SPAN_WARNING("You hear the sound of something hitting something.")
+		)
+		reagents.splash(hit_atom, reagents.total_volume)
+		playsound(src.loc, "sound/effects/metalhit.ogg", 50)
+
+/obj/item/reagent_containers/misc/afterattack(obj/target, mob/user, proximity)
+	if (!proximity || standard_dispenser_refill(user, target) || standard_pour_into(user, target))
+		return TRUE
+	splashtarget(target, user)
+
+/obj/item/reagent_containers/misc/bucket
+	name = "bucket"
+	desc = "It's a bucket."
+	icon = 'icons/obj/janitor.dmi'
+	icon_state = "bucket"
+	item_state = "bucket"
+	center_of_mass = "x=16;y=9"
+	matter = list(MATERIAL_PLASTIC = 280)
+	w_class = ITEM_SIZE_NORMAL
+	amount_per_transfer_from_this = 20
+	possible_transfer_amounts = "10;20;30;60;120;150;180"
+	volume = 180
+	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	has_lid = TRUE
+
+/obj/item/reagent_containers/misc/bucket/wood
+	name = "bucket"
+	desc = "It's a wooden bucket. How rustic."
+	icon_state = "wbucket"
+	item_state = "wbucket"
+	matter = list(MATERIAL_WOOD = 280)
+	volume = 200
+
+/obj/item/reagent_containers/misc/bucket/attackby(var/obj/D, mob/user as mob)
+	if(istype(D, /obj/item/mop))
+		if(reagents.total_volume < 1)
+			to_chat(user, "<span class='warning'>\The [src] is empty!</span>")
+		else
+			reagents.trans_to_obj(D, 5)
+			to_chat(user, "<span class='notice'>You wet \the [D] in \the [src].</span>")
+			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
+		return
+	else
+		return ..()
+
+/obj/item/reagent_containers/misc/bucket/on_update_icon()
+	overlays.Cut()
+	if (!is_open_container())
+		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
+		overlays += lid
+	else if(reagents.total_volume && round((reagents.total_volume / volume) * 100) > 80)
+		var/image/filling = image('icons/obj/reagentfillings.dmi', src, "bucket")
+		filling.color = reagents.get_color()
+		overlays += filling

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -404,7 +404,7 @@
 		/obj/item/reagent_containers/glass/bottle = 75,
 		/obj/item/reagent_containers/glass/beaker = 75,
 		/obj/item/reagent_containers/spray = 50,
-		/obj/item/reagent_containers/glass/bucket = 50,
+		/obj/item/reagent_containers/misc/bucket = 50,
 	)
 
 	can_infect = 0

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -113,7 +113,7 @@
 	return TRUE
 
 /decl/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	return list(SKILL_EVA = SKILL_BASIC) 
+	return list(SKILL_EVA = SKILL_BASIC)
 
 /decl/surgery_step/hardsuit/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!istype(target))
@@ -156,7 +156,7 @@
 		/obj/item/reagent_containers/glass/beaker = 75,
 		/obj/item/reagent_containers/food/drinks/bottle = 75,
 		/obj/item/reagent_containers/food/drinks/glass2 = 75,
-		/obj/item/reagent_containers/glass/bucket = 50
+		/obj/item/reagent_containers/misc/bucket = 50
 	)
 	can_infect = 0
 	blood_level = 0
@@ -169,7 +169,7 @@
 		return affected
 
 /decl/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	return list(SKILL_MEDICAL = SKILL_BASIC) 
+	return list(SKILL_MEDICAL = SKILL_BASIC)
 
 /decl/surgery_step/sterilize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/infinity/code/game/gamemodes/cult/cult_items.dm
+++ b/infinity/code/game/gamemodes/cult/cult_items.dm
@@ -46,7 +46,7 @@
 		user.unEquip(src)
 		qdel(src)
 
-/obj/item/reagent_containers/glass/bucket/wood/cult/New()
+/obj/item/reagent_containers/misc/bucket/wood/cult/New()
 	..()
 	reagents.add_reagent(/datum/reagent/hell_water, 120)
 	update_icon()

--- a/infinity/code/game/gamemodes/cult/runes.dm
+++ b/infinity/code/game/gamemodes/cult/runes.dm
@@ -28,7 +28,7 @@
 	cultname = "summon hellwater"
 
 /obj/effect/rune/hellbucket/cast(var/mob/living/user)
-	new /obj/item/reagent_containers/glass/bucket/wood/cult(get_turf(src))
+	new /obj/item/reagent_containers/misc/bucket/wood/cult(get_turf(src))
 	speak_incantation(user, "N[pick("'","`")]ath chsz'rchesh tza'jink'tumakes!")
 	visible_message("<span class='notice'>\The [src] disappears with a flash of red light.</span>", "You hear a pop.")
 	qdel(src)

--- a/infinity/code/modules/clothing/suits/suits.dm
+++ b/infinity/code/modules/clothing/suits/suits.dm
@@ -61,7 +61,7 @@
 	item_icons = list(slot_wear_suit_str = 'infinity/icons/mob/onmob/onmob_suit.dmi')
 	icon_state = "janitor_jacket"
 	body_parts_covered = UPPER_TORSO|ARMS
-	allowed = list(/obj/item/device/flashlight,/obj/item/device/lightreplacer,/obj/item/storage/bag/trash,/obj/item/grenade/chem_grenade/cleaner,/obj/item/reagent_containers/spray/cleaner, /obj/item/mop, /obj/item/reagent_containers/glass/bucket)
+	allowed = list(/obj/item/device/flashlight,/obj/item/device/lightreplacer,/obj/item/storage/bag/trash,/obj/item/grenade/chem_grenade/cleaner,/obj/item/reagent_containers/spray/cleaner, /obj/item/mop, /obj/item/reagent_containers/misc/bucket)
 
 /obj/item/clothing/suit/storage/tgbomber/militaryjacket
 	name = "military jacket"

--- a/maps/sierra/structures/closets/services.dm
+++ b/maps/sierra/structures/closets/services.dm
@@ -102,7 +102,7 @@
 		/obj/item/clothing/shoes/laceup,
 		/obj/item/storage/pill_bottle/dylovene,
 		/obj/item/reagent_containers/spray/cleaner,
-		/obj/item/reagent_containers/glass/rag,
+		/obj/item/reagent_containers/misc/rag,
 		/obj/item/paper/sierra/bar_permit,
 		/obj/item/gun/projectile/shotgun/doublebarrel/empty,
 		/obj/item/clothing/head/beret/infinity


### PR DESCRIPTION
Тряпка и ведро перемещены из типа стеклянных контейнеров `glass` в новый тип `misc`.

**Фиксит:**
- Разбивание пластмассового и деревянного ведра, а также тряпки на стеклянный осколок.
- Возможность видеть точное количество юнитов жидкостей, так как на тряпке/ведре нет мерных делений.
- В целом ведро с тряпкой прекращают быть респрайтом стеклянных мензурок.