### PR TITLE
Fix: Выпивание залпом

### DIFF
--- a/infinity/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/infinity/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -36,6 +36,7 @@
 				if(!Adjacent(usr))
 					return
 				standard_splash_mob(src, src)
+				return
 			if(!Adjacent(usr))
 				return
 			usr.visible_message(SPAN_NOTICE("[usr] gulped down the whole [src]!"),SPAN_NOTICE("You gulped down the whole [src]!"))


### PR DESCRIPTION
При попытке выпить залпом, при прерывании действия, напиток всё-равно выпивается целиком, что в разы быстрее, чем ждать кулдаун.
Данный PR фиксит это.