### PR TITLE
Windoor Balance Rework

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -220,7 +220,7 @@
 
 /obj/machinery/door/window/attackby(obj/item/I as obj, mob/user as mob)
 
-	//If it's in the process of opening/closing, ignore the click
+	//If it's in the process of opening/closing, ignore the click-
 	if (src.operating == 1)
 		return
 	if(isScrewdriver(I))
@@ -284,28 +284,6 @@
 	if(isCrowbar(I))
 		if(powered() && density)
 			to_chat(user, "<span class='notice'>The airlock's motors resist your efforts to force it.</span>")
-		/* else if(src.operating == -1 && src.p_open)
-			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-			user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")
-			if (do_after(user,40,src))
-				to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
-
-				var/obj/structure/windoor_assembly/wa = new/obj/structure/windoor_assembly(src.loc)
-				if (istype(src, /obj/machinery/door/window/brigdoor))
-					wa.secure = "secure_"
-					wa.SetName("Secure Wired Windoor Assembly")
-				else
-					wa.SetName("Wired Windoor Assembly")
-				if (src.base_state == "right" || src.base_state == "rightsecure")
-					wa.facing = "r"
-				wa.set_dir(src.dir)
-				wa.state = "02"
-				wa.update_icon()
-
-				shatter(src)
-				operating = 0
-				return
-				*/
 		else if(src.p_open)
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -9,7 +9,8 @@
 	maxhealth = 150 //If you change this, consiter changing ../door/window/brigdoor/ health at the bottom of this .dm file
 	health = 150
 	visible = 0.0
-	use_power = POWER_USE_OFF
+	use_power = POWER_USE_IDLE
+	power_channel = ENVIRON
 	stat_immune = NOSCREEN | NOINPUT | NOPOWER
 	uncreated_component_parts = null
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER
@@ -220,8 +221,20 @@
 /obj/machinery/door/window/attackby(obj/item/I as obj, mob/user as mob)
 
 	//If it's in the process of opening/closing, ignore the click
+	to_chat(user, SPAN_NOTICE("arePowerSystemsOn():[src.powered()]"))
 	if (src.operating == 1)
 		return
+	if(isScrewdriver(I))
+		if (src.p_open)
+			src.p_open = 0
+			user.visible_message(SPAN_NOTICE("[user.name] closes the maintenance panel on \the [src]."), SPAN_NOTICE("You close the maintenance panel on \the [src]."))
+			playsound(src.loc, "[GLOB.machinery_exposed_sound[2]]", 20)
+			return
+		else
+			src.p_open = 1
+			user.visible_message(SPAN_NOTICE("[user.name] opens the maintenance panel on \the [src]."), SPAN_NOTICE("You open the maintenance panel on \the [src]."))
+			playsound(src.loc, "[GLOB.machinery_exposed_sound[1]]", 20)
+			return
 
 	if(isCoil(I))
 		if (polarized)
@@ -269,36 +282,71 @@
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			visible_message("<span class='warning'>The glass door was sliced open by [user]!</span>")
 		return 1
+	if(isCrowbar(I))
+		if(powered() && density)
+			to_chat(user, "<span class='notice'>The airlock's motors resist your efforts to force it.</span>")
+		/* else if(src.operating == -1 && src.p_open)
+			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
+			user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")
+			if (do_after(user,40,src))
+				to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
 
-	//If it's emagged, crowbar can pry electronics out.
-	if (src.operating == -1 && isCrowbar(I))
-		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")
-		if (do_after(user,40,src))
-			to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
+				var/obj/structure/windoor_assembly/wa = new/obj/structure/windoor_assembly(src.loc)
+				if (istype(src, /obj/machinery/door/window/brigdoor))
+					wa.secure = "secure_"
+					wa.SetName("Secure Wired Windoor Assembly")
+				else
+					wa.SetName("Wired Windoor Assembly")
+				if (src.base_state == "right" || src.base_state == "rightsecure")
+					wa.facing = "r"
+				wa.set_dir(src.dir)
+				wa.state = "02"
+				wa.update_icon()
 
-			var/obj/structure/windoor_assembly/wa = new/obj/structure/windoor_assembly(src.loc)
-			if (istype(src, /obj/machinery/door/window/brigdoor))
-				wa.secure = "secure_"
-				wa.SetName("Secure Wired Windoor Assembly")
+				shatter(src)
+				operating = 0
+				return
+				*/
+		else if(src.p_open)
+			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
+			user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")
+			if (do_after(user,40,src))
+				to_chat(user, "<span class='notice'>You removed the windoor electronics!</span>")
+
+				var/obj/structure/windoor_assembly/wa = new/obj/structure/windoor_assembly(src.loc)
+				if (istype(src, /obj/machinery/door/window/brigdoor))
+					wa.secure = "secure_"
+					wa.SetName("Secure Wired Windoor Assembly")
+				else
+					wa.SetName("Wired Windoor Assembly")
+				if (src.base_state == "right" || src.base_state == "rightsecure")
+					wa.facing = "r"
+				wa.set_dir(src.dir)
+				wa.state = "02"
+				wa.update_icon()
+				if(operating == -1 || (stat & BROKEN))
+					new /obj/item/stock_parts/circuitboard/broken(src.loc)
+					operating = 0
+				else
+					if (!electronics)
+						create_electronics()
+					electronics.dropInto(loc)
+					electronics = null
+				qdel(src)
+				operating = 0
+				return
+		else if (!powered())
+			if(density)
+				spawn(0)	open(1)
 			else
-				wa.SetName("Wired Windoor Assembly")
-			if (src.base_state == "right" || src.base_state == "rightsecure")
-				wa.facing = "r"
-			wa.set_dir(src.dir)
-			wa.state = "02"
-			wa.update_icon()
-
-			shatter(src)
-			operating = 0
-			return
+				spawn(0)	close(1)
 
 	if (check_force(I, user))
 		return
 
 	src.add_fingerprint(user, 0, I)
 
-	if (src.allowed(user))
+	if (src.allowed(user) && powered())
 		if (src.density)
 			open()
 		else

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -283,7 +283,7 @@
 		return 1
 	if(isCrowbar(I))
 		if(powered() && density)
-			to_chat(user, "<span class='notice'>The airlock's motors resist your efforts to force it.</span>")
+			to_chat(user, "<span class='notice'>The windoor's motors resist your efforts to force it.</span>")
 		else if(src.p_open)
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -221,7 +221,6 @@
 /obj/machinery/door/window/attackby(obj/item/I as obj, mob/user as mob)
 
 	//If it's in the process of opening/closing, ignore the click
-	to_chat(user, SPAN_NOTICE("arePowerSystemsOn():[src.powered()]"))
 	if (src.operating == 1)
 		return
 	if(isScrewdriver(I))


### PR DESCRIPTION
# Описание

* Объект **/obj/machinery/door/window** (стеклянная дверь) и все наследующиеся от него объекты стали зависеть от питания в **area** (области) где они находятся.
* Сделано оно было для создания возможности инженерам вскрывать эти двери не разбивая их.
* Для этого добавлено новое взаимодействие объекта **/obj/item/crowbar** (монтировки) с объектом **/obj/machinery/door/window** (стеклянная дверь). По стандарту теперь если в **area** (области) отключено питание по каналу **Environment**, то это взаимодействие открывает, или закрывает дверь.
* Так же была добавлена возможность вытащить из стеклянной двери плату и перенастроить её по необходимости. Для этого добавлено взаимодействие объекта **/obj/item/screwdriver** (отвертка) с объектом **/obj/machinery/door/window** (стеклянная дверь), которое позволяет открыть панель с платой и вытащить её используя **/obj/item/crowbar** (монтировку) на **/obj/machinery/door/window** (стеклянную дверь) , но сделать это можно только при условии, что дверь открыта, а её панель открыта.

## Основные изменения

* Теперь стеклянную дверь можно открыть не только имея доступ или емаг, но и отключив в помещении свет и вскрыв ломиком.
* Теперь можно разобрать дверь не только использовав на неё ЕМАГ, но и просто открыв её, после чего достаточно сделать комбинацию: отвертка, монтировка, кусачки, сварка. Если не использовать сварку, то раму для установки дверцы можно крутить и поменять её место, после чего прикрутив гаечным ключом можно переместить дверь в другое место.
* Исправлен баг, когда при разборке или починки двери после использования ЕМАГа на неё, дверь разбивалась, а на её  месте появлялась почти готовая новая дверь, в которую надо вставить плату. Теперь дверь не разбивается, даруя дополнительно помимо сломанной платы, ещё и бесплатные провода и кусочек стекла, а спокойно удаляется.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
bugfix: Теперь при вытаскивании сгоревшей от емага платы стеклянная дверь не разбивается, а удаляется, не дублируя выпавшие с неё ресурсы.
tweak: Теперь стеклянную дверь можно открыть ломом в случае, если отключен ток в помещении.
tweak: Теперь стеклянную дверь можно разобрать, если она находится в открытом состоянии.
balance: Стеклянную дверь теперь можно вскрывать не только антагонисту, но и обычному инженеру.
/:cl:
