### PR TITLE
Mapfix: SRV Verne Bridge Holopad, adminpad for ERT base

### DIFF
--- a/maps/antag_spawn/ert/ert_base_inf.dmm
+++ b/maps/antag_spawn/ert/ert_base_inf.dmm
@@ -1067,7 +1067,7 @@
 	},
 /area/map_template/rescue_base/base)
 "cg" = (
-/obj/machinery/hologram/holopad/longrange,
+/obj/machinery/hologram/holopad/adminpad,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},

--- a/maps/away/verne/verne-3.dmm
+++ b/maps/away/verne/verne-3.dmm
@@ -1048,13 +1048,13 @@
 /turf/simulated/floor/tiled/freezer,
 /area/verne/common/kitchen/fridge)
 "fW" = (
-/obj/machinery/hologram/holopad/longrange/remoteship,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/overmap/visitable/ship/verne,
+/obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled/white/monotile,
 /area/verne/bridge)
 "gd" = (


### PR DESCRIPTION
# Описание

Думаю ни для кого не секрет, что когда *кое-кто* делает свои ПРы, они обязательно что-нибудь да сломают. В этот раз я заметил что пропал голопад с мостика на авей-корабле Верне. Этот фикс просто возвращает его.
А еще ЕРТ не может дозвониться до Сьерры, поскольку голопады теперь ограничены по дальности (никто определенно не ожидал такого). Поэтому там он заменен на adminpad.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
bugfix: Verne bridge holopad now exists, again
bugfix: replaced ERT holopad with adminpad
/:cl:
