### PR TITLE
Fix: TGUI AI interaction

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -27,8 +27,6 @@
 	return attack_hand(user)
 
 /obj/machinery/photocopier/attack_hand(mob/user as mob)
-	user.set_machine(src)
-
 	tgui_interact(user)
 
 /obj/machinery/photocopier/tgui_interact(mob/user, datum/tgui/ui, datum/tgui/parent_ui)

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -41,7 +41,14 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 		return
 
 	// The AI can interact with anything it can see nearby, or with cameras while wireless control is enabled.
-	if(!control_disabled && can_see(src_object))
+	var/can_see = (src_object in view(client.view, src))
+	if (!can_see)
+		if (is_in_chassis())
+			can_see = cameranet && cameranet.is_turf_visible(get_turf(src_object))
+		else
+			can_see = get_dist(src_object, src) <= client.view
+
+	if(!control_disabled && can_see)
 		return STATUS_INTERACTIVE
 	return STATUS_CLOSE
 


### PR DESCRIPTION
Интерфейсы TGUI не открывались для ИИ, так как был неправильно использован неправильный прок

Теперь открываются


*(Изменение в photocopier.dm к фиксу не совсем относится. Просто с tgui эта строчка не нужна)*