### PR TITLE
Feat: SFV Sentinel Missile Retrofit

### DIFF
--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -1997,11 +1997,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
-"dR" = (
-/obj/effect/paint/dark_gunmetal,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
 "dS" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -3357,6 +3352,9 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/red,
 /obj/structure/closet/bombcloset,
+/obj/structure/sign/warning/bomb_range{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/command/missiles)
 "gE" = (
@@ -3595,6 +3593,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/missile/antispace,
+/obj/structure/sign/warning/moving_parts{
+	dir = 4;
+	pixel_x = -34
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/command/missiles)
 "ha" = (
@@ -3613,11 +3615,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
-"he" = (
-/obj/effect/paint/dark_gunmetal,
-/obj/structure/sign/warning/bomb_range,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/missiles)
 "hf" = (
@@ -4573,7 +4570,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/warning/vacuum{
 	dir = 4;
-	pixel_x = -45
+	pixel_x = -34
 	},
 /obj/structure/missile/he,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -8361,11 +8358,6 @@
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/missiles)
-"rh" = (
-/obj/structure/lattice,
-/obj/effect/paint/meatstation/lab,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
 "rs" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -8625,8 +8617,7 @@
 /area/ship/patrol/command/missiles)
 "yr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/warning/moving_parts{
-	dir = 4;
+/obj/structure/sign/warning/bomb_range{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8749,6 +8740,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/sign/warning/secure_area{
+	dir = 4;
+	pixel_x = -34
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/command/missiles)
 "CI" = (
@@ -8779,12 +8774,6 @@
 /obj/structure/sign/warning/hot_exhaust,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/port)
-"DB" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/effect/paint/meatstation/lab,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
 "DJ" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -9169,11 +9158,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/command/missiles)
-"Oo" = (
-/obj/effect/paint/dark_gunmetal,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/medbay)
 "Op" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -9612,11 +9596,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"ZZ" = (
-/obj/effect/paint/dark_gunmetal,
-/obj/structure/sign/warning/caution,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
 
 (1,1,1) = {"
 aa
@@ -13950,7 +13929,7 @@ aa
 eF
 sZ
 rs
-rh
+qG
 gh
 qG
 SV
@@ -14070,7 +14049,7 @@ aa
 aa
 aa
 Xc
-DB
+qG
 gh
 gh
 hM
@@ -14194,8 +14173,8 @@ aa
 qt
 qG
 hM
-dR
-dR
+hM
+hM
 hM
 hN
 hM
@@ -14318,11 +14297,11 @@ hM
 hM
 hM
 hM
-he
+hM
 hO
 hM
 hM
-ZZ
+hM
 hM
 qt
 qG
@@ -14693,7 +14672,7 @@ Vm
 vz
 hM
 jk
-Oo
+jk
 FW
 FW
 aa
@@ -14814,8 +14793,8 @@ xy
 Lv
 XG
 hM
-Oo
-Oo
+jk
+jk
 jk
 FW
 FW
@@ -15172,7 +15151,7 @@ QP
 vR
 vR
 hM
-he
+hM
 hS
 hM
 jm

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -4902,20 +4902,17 @@
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jm" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jn" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
@@ -4926,10 +4923,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jq" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jr" = (
@@ -5192,7 +5189,6 @@
 /area/ship/patrol/command/hangar)
 "jQ" = (
 /obj/structure/table/standard,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -5206,6 +5202,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jR" = (
@@ -5214,7 +5211,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jS" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
@@ -5222,6 +5218,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jT" = (
@@ -5254,13 +5251,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/structure/bed/chair/office/comfy/blue{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jW" = (
@@ -5426,7 +5423,6 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
 "kn" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/standard,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10;
@@ -5438,19 +5434,20 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "ko" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kp" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kq" = (
@@ -5467,11 +5464,11 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kr" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "ks" = (
@@ -5688,11 +5685,11 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kN" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kO" = (
@@ -6181,7 +6178,6 @@
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
 	icon_state = "warning"
@@ -6190,19 +6186,20 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "lK" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5;
-	icon_state = "warning"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "lL" = (
@@ -6460,7 +6457,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/adv,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -6469,6 +6465,7 @@
 	pixel_x = -22;
 	req_access = list("ACCESS_CAVALRY")
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "ml" = (
@@ -6757,11 +6754,11 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/fire,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10;
 	icon_state = "warning"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "mO" = (
@@ -6771,7 +6768,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
@@ -6781,6 +6777,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "mP" = (
@@ -8792,7 +8789,6 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/dock)
 "DV" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
@@ -8802,6 +8798,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "DW" = (

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -2524,7 +2524,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/steel_reinforced,
 /obj/machinery/photocopier/faxmachine{
-	send_access = list()
+	send_access = list();
+	department = "Sol 5th Fleet Patrol Craft"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -3346,6 +3347,7 @@
 /obj/item/reagent_containers/ivbag/blood/OMinus,
 /obj/item/reagent_containers/ivbag/blood/OMinus,
 /obj/structure/iv_drip,
+/obj/structure/closet/crate/medical,
 /turf/simulated/floor/tiled/white,
 /area/ship/reaper)
 "gD" = (

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -3895,7 +3895,6 @@
 	dir = 8;
 	id = "bsap"
 	},
-/obj/structure/plasticflaps/airtight,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -7186,7 +7186,7 @@
 /obj/effect/floor_decal/industrial/warning/half,
 /obj/machinery/recharger/wallcharger{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/barracks)

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -265,39 +265,16 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1442;
 	icon_state = "map_injector";
-	id = "emp_in";
+	id = "h2_in";
 	pixel_y = 1;
 	use_power = 1
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/patrol/maintenance/atmos)
 "aE" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	id_tag = "emp_out";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/obj/machinery/air_sensor{
-	id_tag = "emp_sensor"
-	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/patrol/maintenance/atmos)
 "aF" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1442;
-	icon_state = "map_injector";
-	id = "h2_in";
-	pixel_y = 1;
-	use_power = 1
-	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/ship/patrol/maintenance/atmos)
 "aG" = (
@@ -313,9 +290,6 @@
 	pressure_checks_default = 2;
 	pump_direction = 0;
 	use_power = 1
-	},
-/obj/machinery/air_sensor{
-	id_tag = "tox_sensor"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/ship/patrol/maintenance/atmos)
@@ -462,6 +436,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "aT" = (
@@ -506,12 +481,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "aZ" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "ba" = (
@@ -523,28 +500,26 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/obj/structure/sign/warning/compressed_gas,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
+/obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bd" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
+/obj/effect/paint/dark_gunmetal,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/obj/effect/wallframe_spawn/reinforced_phoron,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/atmos)
 "be" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bf" = (
@@ -675,6 +650,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/wallframe_spawn/reinforced_phoron,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bq" = (
@@ -736,20 +712,28 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 2;
+	tag_north = 8;
+	tag_south = 1;
+	tag_west = 5
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bz" = (
-/obj/machinery/atmospherics/binary/pump,
+/obj/structure/closet/crate/internals/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -969,9 +953,9 @@
 /area/ship/patrol/maintenance/atmos)
 "bY" = (
 /obj/machinery/atmospherics/omni/filter{
-	tag_east = 1;
+	tag_east = 2;
 	tag_north = 3;
-	tag_south = 2;
+	tag_south = 1;
 	tag_west = 4
 	},
 /turf/simulated/floor/plating,
@@ -986,33 +970,35 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "ca" = (
-/obj/machinery/atmospherics/omni/filter{
-	tag_east = 2;
-	tag_north = 5;
-	tag_south = 8;
-	tag_west = 1
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cc" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "ce" = (
-/obj/structure/closet/crate/internals/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cf" = (
@@ -1023,6 +1009,9 @@
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	target_pressure = 3500
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cg" = (
@@ -1030,7 +1019,9 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/engine/starboard)
 "ch" = (
@@ -1326,8 +1317,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
@@ -1343,50 +1334,31 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4;
+	target_pressure = 15000
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/atmos)
 "cI" = (
-/obj/machinery/meter,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cJ" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/atmos)
-"cL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cM" = (
@@ -1395,17 +1367,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cO" = (
@@ -1418,9 +1384,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/atmos)
 "cP" = (
@@ -1428,9 +1391,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/engine/starboard)
 "cQ" = (
@@ -1832,6 +1793,8 @@
 	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "dq" = (
@@ -1840,7 +1803,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "dr" = (
@@ -1878,6 +1841,7 @@
 	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/engine/starboard)
 "dy" = (
@@ -1949,6 +1913,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "dG" = (
@@ -2006,6 +1971,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/engine/starboard)
 "dN" = (
@@ -2025,39 +1993,16 @@
 /obj/effect/paint/red,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
-"dP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/ofd)
 "dQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "dR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower)
+/obj/effect/paint/dark_gunmetal,
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
 "dS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
@@ -2068,16 +2013,11 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "dT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "dU" = (
@@ -2149,6 +2089,24 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower/starboard)
+"eb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "ec" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
@@ -2203,12 +2161,17 @@
 	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "eh" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/tank{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -2250,81 +2213,39 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/engine/starboard)
-"em" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "eo" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 23;
-	req_access = list("ACCESS_CAVALRY")
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/command/lasers)
-"ep" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/command/lasers)
-"eq" = (
-/obj/machinery/alarm{
-	pixel_y = 24;
-	req_access = list("ACCESS_CAVALRY")
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/command/lasers)
-"er" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch/maintenance,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/lasers)
-"es" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"ep" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/missile/antispace,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"eq" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/light{
+	dir = 4
 	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"er" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/green,
+/obj/structure/missile/diffusive,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"es" = (
 /obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "et" = (
@@ -2455,44 +2376,53 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
 "eF" = (
-/obj/structure/missile/he,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/pointdefense{
+	initial_id_tag = "patrol_pd"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "eH" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -24
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"eI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"eI" = (
-/turf/simulated/floor/plating,
-/area/ship/patrol/command/lasers)
-"eJ" = (
-/obj/machinery/light/small/red,
-/obj/item/stool/padded,
-/obj/random/cash,
-/turf/simulated/floor/plating,
-/area/ship/patrol/command/lasers)
-"eK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"eJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/table/steel_reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/storage/bible,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"eK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/high_voltage{
-	pixel_x = -32
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
@@ -2576,7 +2506,7 @@
 	},
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "miss_pod";
-	name = "OFD Hatch Lock";
+	name = "Missile Section Lock";
 	pixel_x = 6;
 	pixel_y = 34;
 	req_access = list("ACCESS_CAVALRY_COMMANDER")
@@ -2754,17 +2684,12 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
 "fj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "fk" = (
@@ -3014,30 +2939,17 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
-"fJ" = (
-/obj/machinery/floodlight,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/maintenance/lower)
-"fK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower)
 "fL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
 	},
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "fM" = (
@@ -3232,24 +3144,23 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/patrol/engineering/fussion/control)
 "gg" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/maintenance/lower)
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
 "gh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower)
+/obj/effect/paint/meatstation/lab,
+/obj/effect/paint/meatstation/lab,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
 "gi" = (
-/obj/random/junk,
-/obj/structure/table/rack,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
@@ -3442,17 +3353,12 @@
 /obj/structure/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/ship/reaper)
-"gC" = (
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall,
-/area/ship/patrol/maintenance/lower)
 "gD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/maintenance/lower)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/red,
+/obj/structure/closet/bombcloset,
+/turf/simulated/floor/tiled,
+/area/ship/patrol/command/missiles)
 "gE" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3652,98 +3558,89 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
 "gX" = (
-/obj/structure/sign/warning/bomb_range,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/ofd)
-"gY" = (
-/obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the torpedos launcher door.";
-	id_tag = "patmis_shield";
-	name = "Missile Tube Blast Doors Control";
-	pixel_y = 24;
-	req_access = list("ACCESS_CAVALRY")
-	},
-/obj/machinery/conveyor_switch{
-	id = "patm"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"gZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"ha" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"hb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"hc" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity/bolted{
+	id_tag = "miss_pod";
+	name = "Missile Section"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"gY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access = list("ACCESS_CAVALRY")
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"gZ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/missile/antispace,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"ha" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"hc" = (
+/obj/effect/floor_decal/industrial/outline/green,
+/obj/structure/missile/diffusive,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"hd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "stripe"
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
+"he" = (
+/obj/effect/paint/dark_gunmetal,
+/obj/structure/sign/warning/bomb_range,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
+"hf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"hd" = (
-/obj/structure/closet/bombcloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/patrol/command/ofd)
-"he" = (
-/obj/structure/flora/pottedplant/minitree,
-/obj/effect/floor_decal/corner/red,
-/turf/simulated/floor/tiled,
-/area/ship/patrol/crew/hallway/lower/fore)
-"hf" = (
-/obj/effect/floor_decal/corner/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/ship/patrol/crew/hallway/lower/fore)
+/area/ship/patrol/command/missiles)
 "hg" = (
 /obj/effect/floor_decal/corner/red,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/fore)
@@ -3757,6 +3654,7 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/fore)
 "hj" = (
@@ -3975,76 +3873,82 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
 "hL" = (
-/obj/effect/floor_decal/industrial/outline/green,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/obj/machinery/mass_driver{
+	id_tag = "patmissile";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/patrol/command/missiles)
 "hM" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "hN" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "patm"
+	id = "bsap"
 	},
-/obj/machinery/door/blast/regular/open{
-	density = 0;
-	dir = 4;
-	id_tag = "patmis_shield";
-	name = "Unknown Compartament Shell Loader";
-	opacity = 0
+/obj/machinery/light/small/red{
+	name = "light fixture"
 	},
 /turf/simulated/floor/reinforced,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "hO" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "patm"
+	id = "bsap"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "bsap_space";
+	name = "Missile Compartament Hatch";
+	opacity = 0
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "hP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"hQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "bsap"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
+"hQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "hR" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "hS" = (
-/obj/effect/floor_decal/industrial/warning/half{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4056,11 +3960,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/highsecurity{
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity/bolted{
+	id_tag = "miss_pod";
 	name = "Missile Section"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "hT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4073,8 +3982,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/patrol/command/ofd)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "hU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4087,8 +3999,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
-/area/ship/patrol/crew/hallway/lower/fore)
+/area/ship/patrol/command/missiles)
 "hV" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -4118,8 +4033,15 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -4637,27 +4559,31 @@
 /turf/simulated/floor/plating,
 /area/ship/reaper)
 "iD" = (
-/obj/structure/sign/warning/secure_area{
-	dir = 4;
-	pixel_x = -32
+/obj/effect/paint/meatstation/lab,
+/obj/effect/paint/meatstation/lab,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
 "iE" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"iF" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/sign/warning/vacuum{
+	dir = 4;
+	pixel_x = -45
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/structure/missile/he,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"iF" = (
+/obj/effect/floor_decal/industrial/loading{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "iG" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall,
@@ -5516,21 +5442,11 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "ko" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kp" = (
@@ -5538,11 +5454,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
@@ -5729,6 +5640,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/reagent_containers/chem_disp_cartridge/boron,
 /obj/item/sealgen_case,
 /obj/item/sealgen_case,
 /turf/simulated/floor/tiled,
@@ -7025,11 +6937,22 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/hallway)
 "ne" = (
+/obj/machinery/power/smes/buildable/preset/patrol/engine_gyrotron,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/fussion/control)
 "nf" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	dir = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7382,6 +7305,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/fussion/control)
 "nM" = (
@@ -7651,9 +7579,14 @@
 	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/fussion/control)
@@ -7810,11 +7743,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/barracks)
 "oE" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc/critical{
 	dir = 8;
 	name = "west bump";
@@ -7823,6 +7751,11 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -8094,9 +8027,12 @@
 "pe" = (
 /obj/machinery/fusion_fuel_compressor,
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/fussion/control)
@@ -8266,6 +8202,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/ship/patrol/engineering/fussion/control)
 "pw" = (
@@ -8401,6 +8338,12 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced/airless,
 /area/ship/patrol/engineering/fussion/control)
+"pM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "pO" = (
 /obj/effect/shuttle_landmark/nav_patrol/nav3,
 /turf/space,
@@ -8413,35 +8356,35 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "qG" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/ofd)
-"rk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/missile/he,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
+"rh" = (
+/obj/structure/lattice,
+/obj/effect/paint/meatstation/lab,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
 "rs" = (
-/obj/machinery/mass_driver{
-	id_tag = "patmissile";
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
+"rt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/conveyor_switch{
+	id = "bsap";
+	name = "missile loader switch";
+	pixel_y = 8;
+	pixel_x = 10
+	},
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/command/ofd)
-"rt" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "patm"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/command/ofd)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "rx" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
@@ -8455,14 +8398,24 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
 "rL" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "patmis_shield";
-	name = "OFD Compartament Hatch"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/command/ofd)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "rQ" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -8476,12 +8429,6 @@
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/equipment)
-"si" = (
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
 "sJ" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -8496,14 +8443,10 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/medbay)
 "sZ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "tb" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
@@ -8537,7 +8480,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
 	},
 /turf/simulated/wall/r_wall,
@@ -8583,27 +8526,39 @@
 	},
 /turf/simulated/wall/ocp_wall,
 /area/ship/patrol/engineering/fussion/control)
-"vk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+"vz" = (
+/obj/machinery/computer/ship/missiles{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/green,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"vR" = (
+/obj/structure/railing/mapped,
+/obj/structure/missile/he,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "wa" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/crew/cargo)
 "wf" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "wk" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1442;
@@ -8613,37 +8568,46 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/patrol/engineering/fussion/control)
-"wy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	pixel_x = 0
+"wC" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 26
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/structure/bed/chair/padded/black,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"wM" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/missile/he,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "wN" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/dock)
+"wO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "xr" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
 /area/ship/reaper)
-"xz" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "patm"
+"xy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/command/ofd)
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "ya" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8653,31 +8617,20 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
-"yr" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel_reinforced,
-/obj/item/storage/bible,
-/obj/machinery/button/mass_driver{
-	id_tag = "patmissile";
-	pixel_x = -32;
-	req_access = list("ACCESS_CAVALRY")
+"ye" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
-"yB" = (
-/obj/structure/missile/diffusive,
-/obj/effect/floor_decal/industrial/outline/green,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
-"yR" = (
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/lasers)
-"yS" = (
-/obj/structure/missile/antispace,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"yr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/warning/moving_parts{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "zp" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8687,12 +8640,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
-"zH" = (
-/obj/machinery/computer/ship/missiles{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "zJ" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8720,38 +8667,41 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/barracks/armory)
-"Az" = (
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "AU" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
 "Bl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
 /obj/random/trash,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "Bz" = (
-/obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"BQ" = (
+/obj/effect/floor_decal/industrial/outline/green,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
+"BI" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/ship/navigation{
-	dir = 4
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"BY" = (
+/obj/effect/paint/dark_gunmetal,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
 "Cb" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -8783,24 +8733,24 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/barracks)
 "Ct" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower)
-"CF" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25;
-	req_access = list("ACCESS_CAVALRY")
-	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
+"Cy" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "CI" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -8829,27 +8779,25 @@
 /obj/structure/sign/warning/hot_exhaust,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/port)
-"DD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+"DB" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/effect/paint/meatstation/lab,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/missiles)
 "DJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "bsap"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "DU" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/sign/solgov,
@@ -8883,13 +8831,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/patrol/engineering/fussion/control)
-"Eh" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
 "Ex" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
@@ -8909,6 +8850,17 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/port)
+"FI" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/space)
 "FP" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -8917,7 +8869,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/medbay)
+/area/ship/patrol/command/missiles)
 "FW" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
@@ -8936,12 +8888,10 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "GD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/green,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "GP" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/sleeper{
@@ -8949,20 +8899,36 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
-"Ha" = (
+"Hi" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
-"HP" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/hand_labeler,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/maintenance/lower)
+"Hl" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "HY" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 8
@@ -8977,11 +8943,10 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
 "IG" = (
-/obj/machinery/computer{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/command/lasers)
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/missiles)
 "IW" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -9024,6 +8989,17 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/crew/cargo)
+"Ks" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "Kv" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -9033,9 +9009,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/eva)
+"KC" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
 "KF" = (
 /obj/effect/paint/meatstation/lab,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
 /turf/simulated/wall/r_wall,
@@ -9057,6 +9039,25 @@
 /obj/effect/paint/red,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/port)
+"Lv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/bed/chair/office/comfy/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "LN" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -9077,18 +9078,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
-"LS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"LU" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/missile/antispace{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "Mm" = (
 /obj/machinery/pointdefense{
 	initial_id_tag = "patrol_pd"
@@ -9106,6 +9104,22 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"MF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "MR" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/machinery/atmospherics/binary/pump/on{
@@ -9119,10 +9133,6 @@
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
-"Nm" = (
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_wall,
-/area/space)
 "No" = (
 /obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -9136,13 +9146,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
-"NA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "NY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9152,6 +9155,25 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/patrol/maintenance/engine/port)
+"Ol" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"Oo" = (
+/obj/effect/paint/dark_gunmetal,
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/medbay)
 "Op" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -9161,16 +9183,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/medbay)
-"Oq" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/missile/antispace{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "Ow" = (
 /obj/effect/paint/black,
 /turf/simulated/wall/titanium,
@@ -9210,15 +9222,12 @@
 /turf/space,
 /area/space)
 "PV" = (
-/obj/structure/missile/he,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "PX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -9233,25 +9242,75 @@
 /obj/effect/submap_landmark/joinable_submap/away_scg_patrol,
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower)
+"Qe" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "Qt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
+/obj/machinery/air_sensor{
+	id_tag = "tox_sensor"
 	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced/hydrogen,
 /area/ship/patrol/maintenance/atmos)
 "QH" = (
 /obj/effect/paint/red,
 /obj/structure/sign/warning/hot_exhaust,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
-"Re" = (
-/obj/effect/floor_decal/industrial/outline/blue,
+"QL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"QP" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/missile/he,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
+"Rb" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "fusion_observation_patrol"
+	},
+/obj/effect/wingrille_spawn/reinforced_phoron/full,
+/obj/effect/paint/dark_gunmetal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/ship/patrol/engineering/fussion/control)
+"Rk" = (
+/obj/machinery/button/mass_driver{
+	id_tag = "patmissile";
+	pixel_x = 8;
+	req_access = list("ACCESS_CAVALRY");
+	pixel_y = 35;
+	name = "Missile Launch Button";
+	desc = "Send this deadly thing!"
+	},
+/obj/machinery/button/blast_door{
+	pixel_x = 8;
+	pixel_y = 25;
+	id_tag = "bsap_space";
+	name = "Launch-ready Blast Door"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "Rs" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4
@@ -9290,23 +9349,14 @@
 /turf/space,
 /area/space)
 "SV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "bsap_space";
+	name = "Missile Compartament Hatch"
 	},
-/obj/effect/floor_decal/corner/pink{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/patrol/medbay)
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/patrol/command/missiles)
 "Uk" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
@@ -9315,14 +9365,6 @@
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
-"UV" = (
-/obj/machinery/light/spot,
-/obj/structure/missile/antispace{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "Vb" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -9332,6 +9374,26 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
+"Vf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	pixel_x = -34;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
+"Vm" = (
+/obj/machinery/computer/ship/navigation{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "Vq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9360,20 +9422,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/crew/hallway/lower/port)
-"VG" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "fusion_observation_patrol"
-	},
-/obj/effect/wingrille_spawn/reinforced_phoron/full,
-/obj/effect/paint/dark_gunmetal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/ship/patrol/engineering/fussion/control)
 "VH" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
@@ -9404,11 +9452,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/aft)
-"Wi" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/missile/antispace,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
 "Wn" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -9433,19 +9476,23 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
 "Xc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
+"Xg" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/ofd)
-"Xg" = (
-/obj/machinery/light/spot,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 "Xj" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 5
@@ -9470,20 +9517,24 @@
 /area/ship/patrol/crew/hallway/lower/starboard)
 "XC" = (
 /obj/effect/paint/dark_gunmetal,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
 "XG" = (
-/obj/effect/floor_decal/corner/pink{
-	dir = 9
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/ship/patrol/medbay)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/missiles)
 "XJ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -9563,13 +9614,9 @@
 /area/space)
 "ZZ" = (
 /obj/effect/paint/dark_gunmetal,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/sign/warning/caution,
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/ofd)
+/area/ship/patrol/command/missiles)
 
 (1,1,1) = {"
 aa
@@ -13661,9 +13708,9 @@ aa
 aa
 aa
 aa
-qG
-rL
-qG
+aa
+aa
+aa
 aa
 aa
 aa
@@ -13780,15 +13827,15 @@ aa
 aa
 aa
 aa
-YJ
 aa
-qG
-qG
-rs
-qG
-qG
 aa
-YJ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -13900,18 +13947,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-ty
-aa
+eF
+sZ
+rs
+rh
+gh
 qG
-hM
-rt
-hM
+SV
 qG
-aa
-ty
-aa
+qG
+sZ
+KC
+YJ
 aa
 aa
 aa
@@ -14022,18 +14069,18 @@ aa
 aa
 aa
 aa
-aa
-aa
-ty
-qG
-qG
+Xc
+DB
+gh
+gh
 hM
-xz
+hM
+hL
 hM
 qG
 qG
-ty
-aa
+qG
+FI
 aa
 aa
 aa
@@ -14142,23 +14189,23 @@ aa
 aa
 aa
 aa
-qG
-qG
-qG
-qG
+aa
+aa
 qt
 qG
 hM
-gX
+dR
+dR
+hM
 hN
 hM
 hM
+hM
 qG
 qt
-qG
-qG
-qG
-qG
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14263,25 +14310,25 @@ aa
 aa
 aa
 aa
+aa
+aa
 qG
-hM
-hM
-hM
-hM
-dP
-hM
-hM
-gY
-hO
 iD
 hM
 hM
-dP
 hM
 hM
+he
+hO
 hM
 hM
+ZZ
+hM
+qt
 qG
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14384,27 +14431,27 @@ aa
 aa
 aa
 aa
+aa
+aa
 qG
 qG
+hd
 hM
-Re
-Oq
-zH
-BQ
-HP
+Rk
+rt
 yr
 gZ
 DJ
 iE
 wf
-Re
-LS
-Az
-Re
-UV
+Cy
 hM
-qG
-qG
+hd
+gh
+FW
+aa
+aa
+aa
 aa
 aa
 aa
@@ -14508,25 +14555,25 @@ aa
 aa
 qG
 qG
+qG
 hM
-si
-Xc
-Xc
-eH
-Xc
-Xc
+hd
+hM
+wC
+Qe
+Qe
 ha
 hP
-Eh
-iF
-wy
-DD
-wy
-wy
-Bz
+ha
+Xg
+gY
 hM
-qG
-qG
+FP
+hM
+FW
+FW
+FW
+aa
 aa
 aa
 aa
@@ -14628,27 +14675,27 @@ YJ
 aa
 aa
 al
-al
-al
+qG
 hM
-Wi
-eF
-eF
+hM
+hM
+hd
+hM
 PV
-yB
-GD
-hb
+Qe
+Qe
+iF
 hQ
-iE
-Az
-yB
-rk
-wM
-eF
-yS
+iF
+BI
+eJ
+Vm
+vz
 hM
-qG
-qG
+jk
+Oo
+FW
+FW
 aa
 aa
 YJ
@@ -14750,27 +14797,27 @@ ty
 PF
 al
 al
-tn
-tn
 hM
-Re
-NA
-em
-sZ
-vk
-ZZ
-hc
+hM
+hM
+hM
+BY
+hM
+Qe
+Qe
+hf
+QL
 hR
-CF
+Ks
+rL
+xy
+Lv
+XG
 hM
-hL
-Ha
-em
-em
-Xg
-hM
-qG
-qG
+Oo
+Oo
+jk
+FW
 FW
 PF
 ty
@@ -14872,23 +14919,23 @@ ty
 al
 al
 tn
-tn
-tn
-yR
-yR
-yR
-yR
-yR
+hM
+hc
+wO
+Vf
+eH
+pM
+Qe
+Qe
+Ol
+hM
+gX
 hM
 hM
 hM
-hS
 hM
-jk
-jk
-FP
-jk
-jk
+hM
+hM
 jk
 jk
 jk
@@ -14994,16 +15041,16 @@ VI
 IW
 Cp
 Kv
-tn
-tn
-yR
+hM
+Bz
+ye
 eo
 eI
-yR
-yR
+eb
+Ct
+MF
+Hl
 hM
-hM
-hd
 hT
 hM
 jl
@@ -15116,16 +15163,16 @@ al
 tn
 tn
 cl
-tn
-tn
-yR
+hM
+hM
+er
 ep
-eJ
-yR
-yR
+ep
+QP
+vR
+vR
 hM
-hM
-gX
+he
 hS
 hM
 jm
@@ -15240,16 +15287,16 @@ bD
 cm
 cR
 tn
-yR
+GD
 eq
 IG
-yR
-fJ
 gg
-gC
-he
+LU
+gg
+hM
+gD
 hU
-iG
+hM
 jn
 jS
 kp
@@ -15362,19 +15409,19 @@ bE
 cm
 cS
 tn
-yR
-er
-yR
-yR
-fK
-gh
-gD
-hf
-hV
+hM
+hM
+hM
+hM
+hM
+hM
+hM
+hh
+hY
 iH
 jo
 jT
-XG
+jo
 kP
 lr
 lM
@@ -15490,13 +15537,13 @@ eK
 fj
 fL
 gi
-gC
+Hi
 hg
 hW
 iI
 kq
 jU
-SV
+kq
 kQ
 ls
 lN
@@ -15606,7 +15653,7 @@ bG
 cm
 cU
 tn
-dR
+dQ
 et
 et
 et
@@ -15736,7 +15783,7 @@ eL
 gj
 et
 hi
-hY
+hV
 iG
 jr
 jW
@@ -16094,7 +16141,7 @@ bJ
 ct
 cX
 dz
-dR
+dQ
 et
 eL
 eL
@@ -16216,7 +16263,7 @@ bL
 bL
 cY
 dz
-Ct
+eK
 et
 et
 fk
@@ -17944,7 +17991,7 @@ mE
 nd
 nJ
 md
-VG
+Rb
 pd
 py
 CI
@@ -18184,7 +18231,7 @@ kI
 li
 lH
 kF
-Nm
+md
 ne
 nL
 om
@@ -18897,7 +18944,7 @@ aD
 bb
 by
 cb
-cL
+cJ
 dr
 dI
 ej
@@ -19016,10 +19063,10 @@ aa
 aj
 Uk
 aE
-bb
+bc
 bz
 cc
-cL
+cJ
 dt
 dt
 dt
@@ -19137,11 +19184,11 @@ aa
 aa
 aj
 Uk
-Uk
+Qt
 bc
 bA
 cd
-Qt
+cJ
 du
 dJ
 Rs
@@ -19260,7 +19307,7 @@ aa
 aj
 Uk
 aF
-bd
+bc
 bB
 ce
 cM
@@ -19506,7 +19553,7 @@ Uk
 Uk
 Uk
 Uk
-Uk
+bd
 cO
 Uk
 Uk

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1416,7 +1416,7 @@
 /obj/machinery/door/blast/shutters{
 	dir = 4;
 	id_tag = "ofd_storagep";
-	name = "OFD Ammunition Storage Shutters"
+	name = "Missile Storage Shutters"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2125,6 +2125,7 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper)
 "ei" = (
@@ -4308,13 +4309,13 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "pk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/shutters{
 	dir = 4;
 	id_tag = "ofd_storagep";
-	name = "OFD Ammunition Storage Shutters"
+	name = "Missile Storage Shutters"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "pl" = (
@@ -4893,7 +4894,7 @@
 /area/ship/patrol/maintenance/upper)
 "Du" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "OFD Ammunition Storage"
+	name = "Missile Storage"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -9805,9 +9806,9 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
+aa
+aa
+aa
 aa
 aa
 aa
@@ -9926,11 +9927,11 @@ aa
 aa
 aa
 aa
-ab
-ab
-FT
-ab
-ab
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10047,10 +10048,10 @@ aa
 aa
 aa
 aa
-aa
 ab
 ab
-lD
+ab
+ab
 ab
 ab
 aa
@@ -10167,16 +10168,16 @@ aa
 aa
 aa
 aa
-aa
-aa
 ab
 ab
 ab
-lD
+ab
+ab
+FT
 ab
 ab
 ab
-aa
+ab
 aa
 aa
 aa
@@ -10286,8 +10287,8 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -10300,9 +10301,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10407,8 +10408,8 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -10423,9 +10424,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10528,8 +10529,8 @@ aa
 aa
 aa
 aa
-ab
-ab
+aa
+aa
 ab
 ab
 ab
@@ -10546,9 +10547,9 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
+aa
+aa
+aa
 aa
 aa
 aa
@@ -10670,7 +10671,7 @@ ab
 ab
 ab
 ab
-ab
+aa
 aa
 aa
 aa

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1806,7 +1806,7 @@
 "dB" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/crew/brig/emergency_armory)

--- a/maps/away_inf/sentinel/sentinel_areas.dm
+++ b/maps/away_inf/sentinel/sentinel_areas.dm
@@ -177,7 +177,7 @@
 	req_access = list(access_away_cavalry)
 
 /area/ship/patrol/maintenance/upper/munition
-	name = "\improper OFD Ammunition Storage"
+	name = "\improper Missile Storage"
 	req_access = list(access_away_cavalry)
 
 /area/ship/patrol/maintenance/upper/waste
@@ -223,15 +223,17 @@
 	icon_state = "purple"
 	req_access = list(access_away_cavalry)
 
-/area/ship/patrol/command/ofd
-	name = "\improper Obstruction Field Disperser"
+/area/ship/patrol/command/missiles
+	name = "\improper Missile Section"
 	icon_state = "yellow"
 	req_access = list(access_away_cavalry)
 
+/*
 /area/ship/patrol/command/lasers
 	name = "\improper Abandoned MRSP platform"
 	icon_state = "yellow"
 	req_access = list(access_away_cavalry)
+*/
 
 
 

--- a/maps/away_inf/sentinel/sentinel_presets.dm
+++ b/maps/away_inf/sentinel/sentinel_presets.dm
@@ -95,6 +95,15 @@
 	_output_on = TRUE
 	_fully_charged = TRUE
 
+/obj/machinery/power/smes/buildable/preset/patrol/engine_gyrotron
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil = 1,
+									/obj/item/stock_parts/smes_coil/super_io = 1)
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
+	_fully_charged = TRUE
+
 /obj/machinery/power/smes/buildable/preset/patrol/shuttle
 	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil = 1)
 	_input_maxed = TRUE

--- a/maps/away_inf/sentinel/sentinel_turbolift.dm
+++ b/maps/away_inf/sentinel/sentinel_turbolift.dm
@@ -25,12 +25,12 @@
 	name = "lift (upper deck)"
 	lift_floor_label = "Deck 1"
 	lift_floor_name = "Crew Deck"
-	lift_announce_str = "Arriving at Habitation Deck: Секция гаупвахты. Секция экипажа. Столовая. Капсулы криосна. Спасательые капсулы. Туалет."
+	lift_announce_str = "Arriving at Crew Deck: Секция гаупвахты. Секция экипажа. Столовая. Капсулы криосна. Туалет."
 	base_turf = /turf/simulated/floor
 
 /area/turbolift/sentinel_first
 	name = "lift (lower deck)"
 	lift_floor_label = "Deck 2"
 	lift_floor_name = "Utility Deck"
-	lift_announce_str = "Arriving at Hangar Deck: Shuttle Docks. Cargo Storage. Main Hangar. Supply Office. Expedition Preparation. Mineral Processing."
+	lift_announce_str = "Arriving at Utility Deck: Мостик. Ангар. Атмосферный отсек. Реактор R-UST. Личное снаряжение. Отсек EVA. Секция Пехоты. Ракетный отсек. Медбей."
 	base_turf = /turf/simulated/floor


### PR DESCRIPTION
# Описание

Обновленный отсек для ракетного вооружения, дополнительный SMES для реактора, и разные мелкие фиксы.


Если подробней, то для начала, с чего это вообще задумалось. В процессе великой разработки патрульки ГКК возникли конфликты с этой, поскольку я параллельно тоже делал немного маппинга. Ну и вместо правильного мерджа, один из моих ПРов (#366) просто выкинули. Неприятно, и с этим пришлось что-то делать.
Я посмотрел на то, как ремапнули Сентинел под ракеты, и мне честно не понравилось. Очень похоже, что делалось это все на скорую руку, просто чтобы было, ибо оставшиеся недоработки, вроде не переименованные зоны под прошлую ОФД намекают на это. В целом, мне ремапнутый отсек показался каким-то таким себе.

Я сделал по-своему. Старался рационально использовать доступное пространство, чтобы было предостаточно места для перемещения боеприпасов, при этом сильно не раздувая корабль. В новом ракетном отсеке, для эффективной работы подразумевается наличие двух членов экипажа: оператор и заряжающий (это минимальное разделение обязанностей, в реальности подобного рода система вряд ли бы обслуживалась одним единственным человеком). У обоих есть собственные посты. 
Теперь про сами ракеты и заряжание. Боекомплект первой очереди расположен непосредственно слева и справа от конвейера загрузки (плюс еще 1 ракета, если ее положить на сам этот конвейер). Они нужны для максимальной быстрой перезарядки, когда это действительно важно - достаточно просто толкнуть их на конвейер, и загрузить в трубу для пуска. Вторая очередь уже складируется в другом конце отсека, такие ракеты нужно тащить до конвейера. Ну и третья очередь расположена уже на складе на другой палубе, оттуда ракеты необходимо уже доставлять на место через лифт и на мехе.
Бонусом я добавил отдельный SMES для реактора, который питает гиротрон и APC реакторной. Зачем он нужен? Все просто, питать гиротрон через общую сеть (которая питает все APC корабля, арт. батареи от метеоритов + заряжает Жнец)  с максимальной отдачей при этом в 600 кВт довольно глупо, учитывая что на максимальной мощности гиротрон способен потреблять где-то 1250. Так энергетическая проблема решается, а реактор получает небольшой бекап энергии на случай непредвиденных последствий.
Также поправил оповещения лифта. Мелочь, но возможно она поможет новым на авейке игрокам лучше ориентироваться на карте. И теперь факс работает как должен, на него можно писать, и админы могут управлять действиями патрульки официально через документы. Ура-ура.

## Основные изменения

* Отсек для ракет был кардинально ремапнут.
* Добавлен один SMES для R-UST.
* Исправлены старые названия зон и объектов (кнопки, шлюзы и т.д.), чтобы соответствовать действительности.
* Исправлены сообщения лифта о палубах.
* Возвращены все изменения, сделанные в #366 
* Администрация теперь имеет связь с патрульным судном через факс.
## Скриншоты

![missilemissilemissile](https://user-images.githubusercontent.com/83385197/209411833-16b93d3a-f0eb-42a4-80f7-10b4ee8f94c5.png)
## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Neonvolt
bugfix: fixed outdated Sentinel area and obj names
bugfix: fixed Sentinel lift messages
bugfix: fixed Sentinel fax machine
maptweak: remapped Sentinel missile section
maptweak: added SMES for R-UST needs
/:cl:
