### PR TITLE
Hotfix: SRV Verne core console access

### DIFF
--- a/maps/away/verne/verne-2.dmm
+++ b/maps/away/verne/verne-2.dmm
@@ -1407,6 +1407,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/r_n_d/destructive_analyzer,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/verne/engineering/workshop)
 "gh" = (
@@ -3516,6 +3517,7 @@
 	dir = 1
 	},
 /obj/machinery/r_n_d/circuit_imprinter,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "wQ" = (
@@ -3764,6 +3766,7 @@
 /obj/machinery/computer/rdconsole/core{
 	req_access = list()
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "yO" = (
@@ -4838,6 +4841,7 @@
 /area/verne/engineering/storage)
 "HI" = (
 /obj/machinery/r_n_d/protolathe,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "HQ" = (

--- a/maps/away/verne/verne-2.dmm
+++ b/maps/away/verne/verne-2.dmm
@@ -217,7 +217,11 @@
 "aV" = (
 /obj/structure/table/steel,
 /obj/structure/window/reinforced,
-/obj/item/device/bot_kit,
+/obj/item/stock_parts/circuitboard/helm,
+/obj/item/stock_parts/circuitboard/sensors,
+/obj/item/stock_parts/circuitboard/shuttle_console/explore,
+/obj/item/stock_parts/circuitboard/engine,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "aX" = (
@@ -1828,16 +1832,6 @@
 	initial_gas = null
 	},
 /area/verne/engineering/smresearch/control)
-"jt" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/verne/engineering/workshop)
 "jB" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/conveyor_switch{
@@ -3738,8 +3732,9 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/structure/table/steel,
-/obj/item/paper/verne/science,
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "yE" = (
@@ -3766,12 +3761,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/catfish)
 "yM" = (
-/obj/structure/table/steel,
-/obj/item/stock_parts/circuitboard/engine,
-/obj/item/stock_parts/circuitboard/shuttle_console/explore,
-/obj/item/stock_parts/circuitboard/sensors,
-/obj/item/stock_parts/circuitboard/helm,
-/obj/item/clothing/glasses/welding,
+/obj/machinery/computer/rdconsole/core{
+	req_access = list()
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "yO" = (
@@ -4439,9 +4431,8 @@
 /area/verne/catfish)
 "DP" = (
 /obj/machinery/light,
-/obj/machinery/computer/rdconsole/core{
-	dir = 1
-	},
+/obj/structure/table/steel,
+/obj/item/paper/verne/science,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "DT" = (
@@ -6745,6 +6736,7 @@
 /obj/structure/table/steel,
 /obj/random/advdevice,
 /obj/structure/window/reinforced,
+/obj/item/device/bot_kit,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/verne/engineering/workshop)
 "Yu" = (
@@ -15348,7 +15340,7 @@ wM
 ng
 Yc
 HI
-jt
+jc
 DP
 Sd
 KY

--- a/maps/away/verne/verne-3.dmm
+++ b/maps/away/verne/verne-3.dmm
@@ -1229,7 +1229,9 @@
 	dir = 1;
 	icon_state = "corner_white"
 	},
-/obj/structure/closet/crate/secure/biohazard/alt,
+/obj/structure/closet/crate/secure/biohazard/alt{
+	req_access = list()
+	},
 /obj/machinery/light{
 	dir = 4
 	},


### PR DESCRIPTION
# Описание

Небольшой упущенный момент с доступом, в связи с которым на консоль вернулся доступ РнД (которого у экипажа Верне нет), в результате чего она стала неюзабельной. Теперь все как надо, сдвинул ее чтобы все три девайса к ней привязывались, плюсом пофиксил доступ у ящика для органов (там нужен был доступ хирурга).


## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Neonvolt
bugfix: fixed Verne rnd core console access
bugfix: fixed Verne biowaste crate access
/:cl:
