### PR TITLE
Buffing melee armor on sec voids from sierra

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -348,7 +348,7 @@
 	item_state = "secalt_helm"
 	light_overlay = "helmet_light_alt"
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, //INF WAS ARMOR_MELEE_VERY_HIGH
+		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_PISTOL, //INF WAS ARMOR_BALLISTIC_SMALL
 		laser = ARMOR_LASER_SMALL,
 		bomb = ARMOR_BOMB_PADDED,
@@ -369,7 +369,7 @@
 		)
 //[/INF]
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, //INF WAS ARMOR_MELEE_VERY_HIGH
+		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_PISTOL, //INF WAS ARMOR_BALLISTIC_SMALL
 		laser = ARMOR_LASER_SMALL,
 		bomb = ARMOR_BOMB_PADDED,


### PR DESCRIPTION
# Описание

* Повышение мили защиты скафандров охраны Сьерры с 15 до 30
* Цель: Превращение смешных скафандров в чуть менее смешные скафандры
* Одобренная предложка: https://discord.com/channels/617003227182792704/755125334097133628/1034694979626483742

## Основные изменения

* Повышение мили защиты охранных скафов Сьерры до 30 поинтов

## Changelog

:cl:
tweak: Защита охранных скафандров Сьерры от атак в ближнем бою повышена.
/:cl:
