### PR TITLE
Fix: Removing a non-existent poster bs_60

### DIFF
--- a/code/game/objects/effects/decals/posters/bs12.dm
+++ b/code/game/objects/effects/decals/posters/bs12.dm
@@ -288,8 +288,3 @@
 	icon_state="bsposter59"
 	name = "poster - Miss Science 2299"
 	desc = "A large piece of space-resistant printed paper. This pin-up poster depicts a woman wearing a corporate labcoat, a bikini, and a sheepish grin. She's shyly posing atop some highly specialized research equipment."
-
-/decl/poster/bay_60
-	icon_state="bsposter60"
-	name = "John Fleet poster"
-	desc = "A poster produced by the SCGF. It depicts Petty Officer John Fleet, a character used to boost troop morale, standing in front of the SCG flag proudly. Nobody knows if he really existed."


### PR DESCRIPTION
# Что делает PR
- Удаляет несуществующий в `posters.dmi` постер `bs_60`

Последний постер в файле - `bsposter59`.
`bsposter60` отсутствует, а потому в игре оно выглядит вот так:
![image](https://user-images.githubusercontent.com/32931701/214250639-48f57a24-48de-4852-86bc-08bbd559c963.png)
![image](https://user-images.githubusercontent.com/32931701/214250782-0c8638d8-e912-495d-8575-b258f12e3320.png)

