### PR TITLE
Fix: Telecommunications NTSL basic sanitization

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -213,6 +213,57 @@
 /proc/sanitize_filename(t)
 	return sanitize_simple(t, list("\n"="", "\t"="", "/"="", "\\"="", "?"="", "%"="", "*"="", ":"="", "|"="", "\""="", "<"="", ">"=""))
 
+
+// IE won't receive updates
+// so...
+var/list/html_attr_blacklist = list(
+	"oncancel", "oncanplay", "oncanplaythrough", "onchange", "onclick", "onclose",
+	"oncuechange", "ondblclick", "ondrag", "ondragend", "ondragenter", "ondragleave",
+	"ondragover", "ondragstart", "ondrop", "ondurationchange", "onemptied", "onended",
+	"onerror", "onfocus", "oninput", "oninvalid", "onkeydown", "onkeypress", "onkeyup",
+	"onload", "onloadeddata", "onloadedmetadata", "onloadstart", "onmousedown",
+	"onmouseenter", "onmouseleave", "onmousemove", "onmouseout", "onmouseover",
+	"onmouseup", "onmousewheel", "onpause", "onplay", "onplaying", "onprogress",
+	"onratechange", "onreset", "onresize", "onscroll", "onseeked", "onseeking",
+	"onselect", "onshow", "onstalled", "onsubmit", "onsuspend", "ontimeupdate",
+	"ontoggle", "onvolumechange", "onwaiting", "oncopy", "oncut", "onpaste", "onabort",
+	"onerror", "onresize", "onscroll", "onunload", "onbegin", "onend", "onrepeat"
+)
+var/list/html_allowed_tags = list(
+	"h1", "h2", "h3", "h4", "h5", "h6",
+	"font", "span", "hr", "br",
+	"p", "b", "i", "u", "s"
+)
+var/list/html_allowed_attrs = list(
+	"style", "class",       // Everything
+	"color", "size", "face" // <font>
+)
+
+// It's not perfect, but will work in most cases
+// Don't use it if you don't know what you're doing
+/proc/sanitize_html(var/t)
+	var/static/regex/RegexReplaceHTML = new(@"<(/?)([^> ]*)([^>]*)>", "ig")
+	t = RegexReplaceHTML.Replace(t, /proc/html_replace)
+
+	for (var/w in html_attr_blacklist)
+		t = replacetext(t, w, "a")
+
+	return t
+
+/proc/html_replace(var/match, var/slash, var/tag, var/attrs)
+	if (!(tag in html_allowed_tags))
+		tag = "span"
+
+	var/static/regex/RegexAttrs = new("(\\l+)( *= *\[\"\\'])", "ig")
+	attrs = RegexAttrs.Replace(attrs, /proc/attrs_replace)
+
+	return "<[slash][tag][attrs]>"
+
+/proc/attrs_replace(var/match, var/attr, var/rest)
+	if (!(attr in html_allowed_attrs))
+		return "a[rest]"
+	return "[attr][rest]"
+
 /*
  * Text searches
  */

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -76,7 +76,6 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			copy.transmission_method = 2
 			copy.frequency = signal.frequency
 			copy.data = signal.data.Copy()
-			copy.safe = signal.safe // TMP: If mob has no ckey - don't allow to modify its telecomms message, else - sanitize it
 
 			// Keep the "original" signal constant
 			if(!signal.data["original"])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -491,9 +491,6 @@
 	var/datum/signal/signal = new
 	signal.transmission_method = 2
 
-	// TMP: If mob has no ckey - don't allow to modify its telecomms message, else - sanitize it
-	signal.safe = (M.ckey == null)
-
 	/* --- Try to send a normal subspace broadcast first */
 
 	signal.data = list(

--- a/infinity/code/modules/scripting/Implementations/Telecomms.dm
+++ b/infinity/code/modules/scripting/Implementations/Telecomms.dm
@@ -185,7 +185,7 @@
 		// Backwards-apply variables onto signal data
 		/* sanitize EVERYTHING. fucking players can't be trusted with SHIT */
 
-		signal.data["message"] 	= sanitize_html(interpreter.GetVar("$content"), MAX_MESSAGE_LEN + 512) // 512 extra symbols
+		signal.data["message"] 	= sanitize_html(interpreter.GetVar("$content")) // 512 extra symbols
 		signal.frequency 		= interpreter.GetVar("$freq")
 
 		var/setname = ""
@@ -244,7 +244,7 @@ datum/signal
 		if(!job)
 			job = "?"
 
-		message = sanitize(message, 500)
+		message = sanitize_html(message)
 
 		newsign.data["mob"] = null
 		newsign.data["mobtype"] = /mob/living/carbon/human

--- a/infinity/code/modules/scripting/Implementations/Telecomms.dm
+++ b/infinity/code/modules/scripting/Implementations/Telecomms.dm
@@ -185,10 +185,7 @@
 		// Backwards-apply variables onto signal data
 		/* sanitize EVERYTHING. fucking players can't be trusted with SHIT */
 
-		// TMP: If mob has no ckey - don't allow to modify its telecomms message, else - sanitize it
-		if (!signal.safe)
-			signal.data["message"] 	= sanitize(interpreter.GetVar("$content"), MAX_MESSAGE_LEN + 512) // 512 extra symbols
-
+		signal.data["message"] 	= sanitize_html(interpreter.GetVar("$content"), MAX_MESSAGE_LEN + 512) // 512 extra symbols
 		signal.frequency 		= interpreter.GetVar("$freq")
 
 		var/setname = ""


### PR DESCRIPTION
# Что делает этот PR
- Добавляет какую-никакую вайтлист-сантизацию HTML кода в NTSL
- Удаляет временное решение полной его санитизации

## Плохо?
Я знаю, что это не идеальное решение, что HTML санитизировать через регулярки нельзя, но этот код с громадной вероятностью убъёт тег, которого нет в вайтлисте, как и не разрешённый аттрибут. А также со 100% вероятностью удалит js-аттрибут, так как они прописаны все вручную - IE обновлений уже больше не получит, а потому и аттрибутов новых точно не появится.
