### PR TITLE
Farfleet and Sentinel fixes

### DIFF
--- a/maps/away/verne/verne-3.dmm
+++ b/maps/away/verne/verne-3.dmm
@@ -2468,6 +2468,9 @@
 	dir = 9
 	},
 /obj/machinery/light/spot,
+/obj/structure/panic_button{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/white,
 /area/verne/bridge)
 "rR" = (

--- a/maps/away_inf/bearcat/bearcat-2.dmm
+++ b/maps/away_inf/bearcat/bearcat-2.dmm
@@ -165,7 +165,6 @@
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad/longrange/remoteship,
 /turf/simulated/floor/tiled/dark/usedup,
 /area/ship/scrap/command/bridge)
 "aw" = (
@@ -325,6 +324,9 @@
 /obj/item/storage/backpack/dufflebag/syndie,
 /obj/item/storage/box/ammo/shotgunshells,
 /obj/item/handcuffs,
+/obj/structure/panic_button{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "aL" = (
@@ -2832,9 +2834,6 @@
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -25
-	},
-/obj/structure/closet/medical_wall/filled{
-	pixel_y = -32
 	},
 /obj/item/tape_roll,
 /obj/item/retractor,

--- a/maps/away_inf/farfleet/farfleet-1.dmm
+++ b/maps/away_inf/farfleet/farfleet-1.dmm
@@ -837,7 +837,7 @@
 /obj/machinery/door/airlock/multi_tile/glass/terran{
 	name = "Hallway"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "ce" = (
 /obj/structure/cable{
@@ -1872,7 +1872,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/half,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/crew/comms)
 "eu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1995,14 +1995,16 @@
 "eL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/warning/server_room,
-/obj/effect/wingrille_spawn/reinforced,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/dark_gunmetal,
 /turf/simulated/floor,
 /area/ship/farfleet/crew/comms)
 "eM" = (
 /obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/dark_gunmetal,
 /turf/simulated/floor,
 /area/ship/farfleet/crew/comms)
 "eN" = (
@@ -2209,7 +2211,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/engineering/reactor)
 "fh" = (
 /obj/machinery/light/spot,
@@ -2306,7 +2308,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/ship/farfleet/crew/kitchen)
 "fs" = (
 /obj/machinery/door/firedoor,
@@ -2729,7 +2731,7 @@
 	icon_state = "warninghalf"
 	},
 /obj/machinery/door/airlock/multi_tile/glass/terran,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "gs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -3040,7 +3042,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "hi" = (
 /obj/structure/cable{
@@ -3119,7 +3121,7 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "ht" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -4067,7 +4069,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_titanium,
+/turf/simulated/wall/ocp_wall,
 /area/ship/farfleet/command/launcher/north)
 "kO" = (
 /obj/machinery/sleeper{
@@ -4599,7 +4601,7 @@
 	req_access = list("ACCESS_ICCGN");
 	name = "Maintenance Access"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/engineering/atmos_equipment)
 "ml" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4689,7 +4691,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "mw" = (
 /obj/machinery/door/blast/shutters{
@@ -4764,7 +4766,7 @@
 /obj/machinery/door/airlock/autoname/maintenance,
 /obj/effect/floor_decal/industrial/warning/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/maintenance/lower)
 "mG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4805,7 +4807,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/engineering/storage)
 "mN" = (
 /obj/machinery/door/firedoor,
@@ -5015,7 +5017,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/engineering/reactor)
 "ny" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -5275,6 +5277,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/item/reagent_containers/misc/bucket,
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/reinforced,
 /area/ship/farfleet/engineering/reactor)
 "oa" = (
@@ -5475,7 +5479,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/engineering/hallway)
 "oF" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -5611,7 +5615,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/turf/simulated/wall/r_titanium,
+/turf/simulated/wall/ocp_wall,
 /area/ship/farfleet/command/launcher)
 "oX" = (
 /obj/structure/hygiene/shower{
@@ -5798,7 +5802,7 @@
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew)
 "pB" = (
 /obj/machinery/door/blast/regular/open{
@@ -5896,7 +5900,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_titanium,
+/turf/simulated/wall/ocp_wall,
 /area/ship/farfleet/command/launcher)
 "qd" = (
 /obj/structure/railing/mapped,
@@ -6071,7 +6075,7 @@
 	id_tag = "missile_launcher_north";
 	name = "Starboard Launcher"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/launcher/north)
 "rR" = (
 /obj/structure/window/reinforced/bar{
@@ -6185,7 +6189,7 @@
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew)
 "su" = (
 /obj/machinery/airlock_sensor{
@@ -6307,7 +6311,7 @@
 /obj/effect/floor_decal/industrial/warning/half{
 	icon_state = "warninghalf"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "ti" = (
 /obj/structure/hygiene/toilet{
@@ -6424,10 +6428,7 @@
 /area/ship/farfleet/maintenance/lower)
 "tY" = (
 /obj/machinery/door/airlock/autoname/maintenance,
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/monotile,
 /area/ship/farfleet/crew/kitchen)
 "ug" = (
 /obj/effect/floor_decal/borderfloorwhite,
@@ -6730,7 +6731,7 @@
 	pixel_x = 0
 	},
 /obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall/r_titanium,
+/turf/simulated/wall/ocp_wall,
 /area/ship/farfleet/command/launcher/north)
 "wH" = (
 /obj/machinery/power/smes/buildable/preset/farfleet/engine_main,
@@ -7088,7 +7089,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/farfleet/command/bridge)
 "zi" = (
-/obj/machinery/power/port_gen/pacman/super/potato,
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8";
@@ -7103,6 +7103,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/power/port_gen/pacman/super/potato/reactor,
 /turf/simulated/floor/reinforced,
 /area/ship/farfleet/engineering/reactor)
 "zj" = (
@@ -7294,7 +7295,7 @@
 	icon_state = "pdoor0";
 	id_tag = "iccg_door_bridge"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/bridge)
 "At" = (
 /obj/machinery/light,
@@ -7305,7 +7306,7 @@
 	name = "Galley"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white/monotile,
 /area/ship/farfleet/crew/kitchen)
 "Ax" = (
 /obj/machinery/door/firedoor,
@@ -7360,6 +7361,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/ship/farfleet/maintenance/lower/starboard)
+"AQ" = (
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/wall/ocp_wall,
+/area/ship/farfleet/command/launcher)
 "AT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -7714,7 +7719,7 @@
 	icon_state = "pdoor0";
 	id_tag = "iccg_door_bridge"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/bridge)
 "DX" = (
 /obj/effect/paint/dark_gunmetal,
@@ -7830,7 +7835,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/launcher)
 "EV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -8001,8 +8006,6 @@
 /turf/simulated/floor/plating,
 /area/ship/farfleet/command/bridge)
 "Gq" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/reagent_containers/chem_disp_cartridge/vodka,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -8011,6 +8014,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/reinforced,
 /area/ship/farfleet/engineering/reactor)
 "Gu" = (
@@ -8161,6 +8165,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/farfleet/command/launcher)
+"Hq" = (
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/wall/ocp_wall,
+/area/ship/farfleet/command/launcher/north)
 "Hr" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor,
@@ -8888,7 +8896,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/cryo)
 "MP" = (
 /obj/effect/paint/dark_gunmetal,
@@ -9061,7 +9069,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "Oo" = (
 /obj/machinery/door/window/brigdoor{
@@ -9233,7 +9241,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/eva)
 "Pb" = (
 /obj/machinery/power/shield_generator,
@@ -9372,7 +9380,7 @@
 /obj/machinery/door/airlock/multi_tile/glass/terran{
 	name = "Hallway"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "PV" = (
 /obj/effect/paint/dark_gunmetal,
@@ -9396,7 +9404,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/launcher/north)
 "Qi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -10199,7 +10207,7 @@
 /obj/machinery/door/airlock/multi_tile/glass/terran{
 	name = "Hallway"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/lower)
 "VL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -10220,7 +10228,7 @@
 	id_tag = "missile_launcher_south";
 	name = "Port Launcher"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/command/launcher)
 "VN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -10653,7 +10661,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/cryo)
 "Yj" = (
 /obj/structure/cable{
@@ -15217,12 +15225,12 @@ aa
 aa
 aa
 eO
-PV
-PV
-PV
-PV
-PV
-PV
+Hq
+Hq
+Hq
+Hq
+Hq
+Hq
 jt
 NK
 Jp
@@ -15238,12 +15246,12 @@ pk
 zA
 NK
 cv
-RA
-RA
-RA
-RA
-RA
-RA
+AQ
+AQ
+AQ
+AQ
+AQ
+AQ
 eO
 aa
 aa
@@ -15334,12 +15342,12 @@ aa
 aa
 aa
 aa
-PV
-PV
-PV
-PV
+Hq
+Hq
+Hq
+Hq
 wE
-PV
+Hq
 LD
 LD
 LD
@@ -15365,12 +15373,12 @@ WA
 vy
 vy
 vy
-RA
+AQ
 oW
-RA
-RA
-RA
-RA
+AQ
+AQ
+AQ
+AQ
 aa
 aa
 aa
@@ -15456,7 +15464,7 @@ aa
 aa
 aa
 aa
-PV
+Hq
 LD
 LD
 LD
@@ -15492,7 +15500,7 @@ Kh
 vy
 vy
 vy
-RA
+AQ
 aa
 aa
 aa

--- a/maps/away_inf/farfleet/farfleet-2.dmm
+++ b/maps/away_inf/farfleet/farfleet-2.dmm
@@ -185,7 +185,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/upper)
 "av" = (
 /obj/machinery/door/firedoor,
@@ -474,7 +474,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/barracks)
 "be" = (
 /obj/structure/closet/secure_closet/guncabinet/farfleet{
@@ -760,7 +760,7 @@
 	id_tag = "anomaly-iccg";
 	name = "Storage"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/maintenance/upper/anomaly)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -905,7 +905,7 @@
 /obj/effect/floor_decal/industrial/warning/half{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/upper)
 "ca" = (
 /obj/structure/bed/chair/shuttle/blue{
@@ -1340,7 +1340,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/crew/hallway/upper)
 "cZ" = (
 /obj/machinery/power/engine/ion{
@@ -1598,7 +1598,7 @@
 	dir = 9
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/maintenance/upper/anomaly)
 "dD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1772,7 +1772,7 @@
 /obj/effect/floor_decal/industrial/warning/half{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/upper)
 "dW" = (
 /obj/effect/paint/dark_gunmetal,
@@ -2295,7 +2295,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/maintenance/upper/anomaly)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -2632,7 +2632,7 @@
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/crew/hallway/upper)
 "fZ" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -4307,7 +4307,7 @@
 /obj/machinery/door/airlock/multi_tile/terran{
 	name = "Armory"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/crew/hallway/upper)
 "uA" = (
 /obj/structure/railing/mapped,
@@ -4358,7 +4358,7 @@
 	icon_state = "pdoor0";
 	id_tag = "hangar-iccg"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/command/snz_exterior_dock)
 "uI" = (
 /obj/effect/floor_decal/industrial/danger{
@@ -5618,7 +5618,7 @@
 /obj/machinery/door/airlock/glass/terran{
 	name = "Storage"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/farfleet/maintenance/upper/anomaly)
 "FV" = (
 /obj/machinery/chem_master/condimaster{
@@ -5670,7 +5670,7 @@
 /obj/machinery/door/airlock/multi_tile/terran{
 	name = "Hangar"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/command/snz_exterior_dock)
 "Gj" = (
 /obj/effect/floor_decal/industrial/danger/corner{
@@ -5760,7 +5760,7 @@
 /obj/effect/floor_decal/industrial/warning/half{
 	icon_state = "warninghalf"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/monotile,
 /area/ship/farfleet/command/snz_exterior_dock)
 "GY" = (
 /obj/item/missile_equipment/payload/antimissile,

--- a/maps/away_inf/liberia/liberia.dmm
+++ b/maps/away_inf/liberia/liberia.dmm
@@ -4496,7 +4496,7 @@
 /obj/machinery/vending/cigarette{
 	name = "hacked cigarette machine";
 	prices = list();
-	products = list(/obj/item/storage/fancy/cigarettes = 10, /obj/item/storage/box/matches = 10, /obj/item/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/storage/fancy/cigarettes=10,/obj/item/storage/box/matches=10,/obj/item/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -5619,6 +5619,9 @@
 	},
 /obj/structure/cable/blue,
 /obj/effect/floor_decal/corner/blue/three_quarters,
+/obj/structure/panic_button{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberia/bridge{
 	name = "Liberia - Bridge"

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -2530,6 +2530,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/panic_button{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
 "eU" = (

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1620,9 +1620,10 @@
 	dir = 8
 	},
 /obj/structure/table/rack,
-/obj/item/missile_equipment/payload/antimissile,
-/obj/item/missile_equipment/payload/antimissile,
-/obj/item/missile_equipment/payload/antimissile,
+/obj/item/missile_equipment/thruster/planet,
+/obj/item/missile_equipment/thruster/planet,
+/obj/item/missile_equipment/thruster/hunter,
+/obj/item/missile_equipment/thruster/hunter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "di" = (
@@ -2905,6 +2906,11 @@
 	dir = 1
 	},
 /obj/structure/table/rack,
+/obj/item/missile_equipment/autoarm,
+/obj/item/missile_equipment/autoarm,
+/obj/item/missile_equipment/autoarm,
+/obj/item/missile_equipment/autoarm,
+/obj/item/missile_equipment/autoarm,
 /obj/item/missile_equipment/autoarm,
 /obj/item/missile_equipment/autoarm,
 /obj/item/missile_equipment/autoarm,
@@ -4296,7 +4302,7 @@
 /area/ship/patrol/maintenance/upper)
 "oM" = (
 /obj/structure/railing/mapped,
-/obj/item/toy/plushie/dakimakura,
+/obj/structure/plushie/drone,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "pk" = (
@@ -4635,6 +4641,8 @@
 /obj/item/missile_equipment/payload/emp,
 /obj/item/missile_equipment/payload/emp,
 /obj/item/missile_equipment/payload/emp,
+/obj/item/missile_equipment/payload/emp,
+/obj/item/missile_equipment/payload/explosive,
 /obj/item/missile_equipment/payload/explosive,
 /obj/item/missile_equipment/payload/explosive,
 /obj/item/missile_equipment/payload/explosive,

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1620,9 +1620,9 @@
 	dir = 8
 	},
 /obj/structure/table/rack,
-/obj/item/missile_equipment/passenger,
-/obj/item/missile_equipment/passenger,
-/obj/item/missile_equipment/passenger,
+/obj/item/missile_equipment/payload/antimissile,
+/obj/item/missile_equipment/payload/antimissile,
+/obj/item/missile_equipment/payload/antimissile,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "di" = (

--- a/maps/away_inf/yacht/yacht.dmm
+++ b/maps/away_inf/yacht/yacht.dmm
@@ -150,6 +150,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/structure/panic_button{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/walnut,
 /area/yacht/bridge)
 "at" = (

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -2259,6 +2259,9 @@
 	dir = 4
 	},
 /obj/structure/table/steel,
+/obj/structure/panic_button{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
 "en" = (
@@ -31036,6 +31039,9 @@
 /obj/machinery/cell_charger,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/paint/dark_gunmetal,
+/obj/structure/panic_button{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/guppy_hangar/start)
 "YZ" = (

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -14128,6 +14128,9 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
+/obj/structure/panic_button{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/nano)
 "ayY" = (


### PR DESCRIPTION
# Описание

* Фиксы минорных упущений на карте

## Основные изменения

* Заменены wingrille на православные стенки с окнами. 
* Переставлены под двери упущенные тайлы
* По просьбам трудящихся водка в реакторной заменена на охладитель (не понимаю что вам не нравилось?) а реактор на тот, который дружит с хладагентом
* У ЦПСС убраны десантные торпеды

:cl:
maptweak: edited iggc and solgov patrol ship maps
/:cl:
