### PR TITLE
Missiles probably fix

### DIFF
--- a/code/modules/overmap/projectiles/missiles/missile.dm
+++ b/code/modules/overmap/projectiles/missiles/missile.dm
@@ -28,7 +28,7 @@
 	var/entered_away = FALSE
 	var/list/equipment = list()
 	var/obj/effect/overmap/projectile/overmap_missile = null
-	var/lifetime = 60 SECONDS
+	var/lifetime = 120 SECONDS
 	var/obj/effect/overmap/origin = null
 
 /obj/structure/missile/proc/get_additional_info()

--- a/code/modules/overmap/projectiles/missiles/missile.dm
+++ b/code/modules/overmap/projectiles/missiles/missile.dm
@@ -75,7 +75,7 @@
 // Move to the overmap until we encounter a new z
 /obj/structure/missile/touch_map_edge()
 
-	addtimer(CALLBACK(src, .proc/expire), lifetime)
+	addtimer(CALLBACK(src, .proc/expire), lifetime, TIMER_NO_HASH_WAIT)
 
 	//Missile destroyed if it fails to hit something
 	if(entered_away)


### PR DESCRIPTION
Имеется проблема с таймерами, которая, по какой-то причине, превращает таймер заведенный на одну минуту в тыкву, а таймер на две минуты в таймер на одну минуту. Я не знаю почему так происходит, но из-за этого сломались только торпеды, по этому костылим что бы хотя бы работало. А то не очень хорошо получается, когда прижмет - торпеды резко не будут работать. Если есть предложения почему это может быть именно так с радостью готов выслушать.