### PR TITLE
Improved OFD for solship

### DIFF
--- a/code/modules/overmap/disperser/disperser_charge.dm
+++ b/code/modules/overmap/disperser/disperser_charge.dm
@@ -6,7 +6,7 @@
 	var/chargetype
 	var/chargedesc
 
-/obj/structure/ship_munition/disperser_charge/proc/fire(turf/target, strength, range)
+/obj/structure/ship_munition/disperser_charge/proc/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
 	CRASH("OFD charge firing logic not set!")
 
 /obj/structure/ship_munition/disperser_charge/fire
@@ -16,16 +16,35 @@
 	chargetype = OVERMAP_WEAKNESS_FIRE
 	chargedesc = "ENFER"
 
-/obj/structure/ship_munition/disperser_charge/fire/fire(turf/target, strength, range)
+/obj/structure/ship_munition/disperser_charge/fire/military
+	name = "M1050-NPLM"
+	desc = "A charge to power the military impulse gun. This charge is designed to release a localised fire on impact."
+	chargedesc = "NPLM"
+
+/obj/structure/ship_munition/disperser_charge/fire/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	if(shield_active_EM && shield_active_KTC)
+		return
 	for(var/turf/T in range(range, target))
 		var/obj/effect/fake_fire/bluespace/disperserf = new(T)
 		disperserf.lifetime = strength * 20
+
+/obj/structure/ship_munition/disperser_charge/fire/military/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	if(shield_active_EM && shield_active_KTC)
+		return
+	for(var/turf/T in range(range * 1.5, target))
+		var/obj/effect/fake_fire/napalm/disperserf = new(T)
+		disperserf.lifetime = strength * 5 SECONDS
 
 /obj/effect/fake_fire/bluespace
 	name = "bluespace fire"
 	color = COLOR_BLUE
 	pressure = 1500
 
+/obj/effect/fake_fire/napalm
+	name = "napalm"
+	color = COLOR_SUN
+	pressure = 5000
+	firelevel = 25
 
 /obj/structure/ship_munition/disperser_charge/emp
 	name = "EM2-QUASAR charge"
@@ -34,8 +53,21 @@
 	chargetype = OVERMAP_WEAKNESS_EMP
 	chargedesc = "QUASAR"
 
-/obj/structure/ship_munition/disperser_charge/emp/fire(turf/target, strength, range)
+/obj/structure/ship_munition/disperser_charge/emp/military
+	name = "M850-EM"
+	desc = "A charge to power the military impulse gun. This charge is designed to release a blast of electromagnetic pulse on impact."
+	chargedesc = "EMS"
+
+/obj/structure/ship_munition/disperser_charge/emp/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	if(shield_active_EM && shield_active_KTC)
+		return
 	empulse(target, strength * range / 3, strength * range)
+
+/obj/structure/ship_munition/disperser_charge/emp/military/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	var/shield_mod = 1
+	if(shield_active_EM)
+		shield_mod = 0.5
+	empulse(target, strength * range / 2 * shield_mod , strength * range * 1.5 * shield_mod)
 
 /obj/structure/ship_munition/disperser_charge/mining
 	name = "MN3-BERGBAU charge"
@@ -44,7 +76,9 @@
 	chargetype = OVERMAP_WEAKNESS_MINING
 	chargedesc = "BERGBAU"
 
-/obj/structure/ship_munition/disperser_charge/mining/fire(turf/target, strength, range)
+/obj/structure/ship_munition/disperser_charge/mining/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	if(shield_active_EM && shield_active_KTC)
+		return
 	var/list/victims = range(range * 3, target)
 	for(var/turf/simulated/mineral/M in victims)
 		if(prob(strength * 100 / 6)) //6 instead of 5 so there are always leftovers
@@ -60,8 +94,21 @@
 	chargetype = OVERMAP_WEAKNESS_EXPLOSIVE
 	chargedesc = "INDARRA"
 
-/obj/structure/ship_munition/disperser_charge/explosive/fire(turf/target, strength, range)
+/obj/structure/ship_munition/disperser_charge/explosive/military
+	name = "M950-HE"
+	desc = "A charge to power the military impulse gun. This charge is designed to explode on impact."
+	chargedesc = "HES"
+
+/obj/structure/ship_munition/disperser_charge/explosive/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	if(shield_active_EM && shield_active_KTC)
+		return
 	explosion(target,max(1,strength * range / 10),strength * range / 7.5,strength * range / 5)
+
+/obj/structure/ship_munition/disperser_charge/explosive/military/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
+	var/shield_mod = 1
+	if(shield_active_KTC)
+		shield_mod = 0.75
+	explosion(target,max(1,strength * range / 8 * shield_mod),strength * range / 6 * shield_mod,strength * range / 4 * shield_mod)
 
 /obj/structure/closet/odst
 	name = "OFD droppod"

--- a/code/modules/overmap/disperser/disperser_charge.dm
+++ b/code/modules/overmap/disperser/disperser_charge.dm
@@ -32,8 +32,9 @@
 	if(shield_active_EM && shield_active_KTC)
 		return
 	for(var/turf/T in range(range * 1.5, target))
-		var/obj/effect/fake_fire/napalm/disperserf = new(T)
+		var/obj/effect/fake_fire/napalm/disperserf
 		disperserf.lifetime = strength * 5 SECONDS
+		disperserf = new(T)
 
 /obj/effect/fake_fire/bluespace
 	name = "bluespace fire"

--- a/code/modules/overmap/disperser/disperser_charge.dm
+++ b/code/modules/overmap/disperser/disperser_charge.dm
@@ -31,21 +31,21 @@
 /obj/structure/ship_munition/disperser_charge/fire/military/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
 	if(shield_active_EM && shield_active_KTC)
 		return
-	for(var/turf/T in range(range * 1.5, target))
-		var/obj/effect/fake_fire/napalm/disperserf
-		disperserf.lifetime = strength * 5 SECONDS
-		disperserf = new(T)
+	var/datum/reagent/napalm/napalm_liquid = new /datum/reagent/napalm
+	napalm_liquid.volume = 5 * strength
+	for(var/atom/A in view(range, target))
+		if(ismob(A))
+			napalm_liquid.touch_mob(A, 10 * strength)
+		if(isturf(A))
+			napalm_liquid.touch_turf(A, TRUE)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(3, 1, target)
+	addtimer(CALLBACK(s, /datum/effect/effect/system/proc/start), 0.1 SECONDS)
 
 /obj/effect/fake_fire/bluespace
 	name = "bluespace fire"
 	color = COLOR_BLUE
 	pressure = 1500
-
-/obj/effect/fake_fire/napalm
-	name = "napalm"
-	color = COLOR_SUN
-	pressure = 5000
-	firelevel = 25
 
 /obj/structure/ship_munition/disperser_charge/emp
 	name = "EM2-QUASAR charge"

--- a/code/modules/overmap/disperser/disperser_charge.dm
+++ b/code/modules/overmap/disperser/disperser_charge.dm
@@ -59,7 +59,7 @@
 	chargedesc = "EMS"
 
 /obj/structure/ship_munition/disperser_charge/emp/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
-	if(shield_active_EM && shield_active_KTC)
+	if(shield_active_EM)
 		return
 	empulse(target, strength * range / 3, strength * range)
 
@@ -77,7 +77,7 @@
 	chargedesc = "BERGBAU"
 
 /obj/structure/ship_munition/disperser_charge/mining/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
-	if(shield_active_EM && shield_active_KTC)
+	if(shield_active_KTC)
 		return
 	var/list/victims = range(range * 3, target)
 	for(var/turf/simulated/mineral/M in victims)
@@ -100,7 +100,7 @@
 	chargedesc = "HES"
 
 /obj/structure/ship_munition/disperser_charge/explosive/fire(turf/target, strength, range, shield_active_EM, shield_active_KTC)
-	if(shield_active_EM && shield_active_KTC)
+	if(shield_active_KTC)
 		return
 	explosion(target,max(1,strength * range / 10),strength * range / 7.5,strength * range / 5)
 

--- a/code/modules/overmap/disperser/disperser_circuit.dm
+++ b/code/modules/overmap/disperser/disperser_circuit.dm
@@ -3,7 +3,7 @@
 	build_path = /obj/machinery/computer/ship/disperser
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 
-/obj/item/stock_parts/circuitboard/disperser
+/obj/item/stock_parts/circuitboard/disperser/military
 	name = T_BOARD("impulse cannon control")
 	build_path = /obj/machinery/computer/ship/disperser/military
 	origin_tech = list(TECH_ENGINEERING = 7, TECH_COMBAT = 7, TECH_BLUESPACE = 7)

--- a/code/modules/overmap/disperser/disperser_circuit.dm
+++ b/code/modules/overmap/disperser/disperser_circuit.dm
@@ -3,6 +3,11 @@
 	build_path = /obj/machinery/computer/ship/disperser
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 
+/obj/item/stock_parts/circuitboard/disperser
+	name = T_BOARD("impulse cannon control")
+	build_path = /obj/machinery/computer/ship/disperser/military
+	origin_tech = list(TECH_ENGINEERING = 7, TECH_COMBAT = 7, TECH_BLUESPACE = 7)
+
 /obj/item/stock_parts/circuitboard/disperserfront
 	name = T_BOARD("obstruction field disperser beam generator")
 	build_path = /obj/machinery/disperser/front

--- a/code/modules/overmap/disperser/disperser_console.dm
+++ b/code/modules/overmap/disperser/disperser_console.dm
@@ -25,7 +25,12 @@
 	var/range = 1 //range of the explosion
 	var/strength = 1 //strength of the explosion
 	var/next_shot = 0 //round time where the next shot can start from
-	var/const/coolinterval = 2 MINUTES //time to wait between safe shots in deciseconds
+	var/coolinterval = 2 MINUTES //time to wait between safe shots in deciseconds
+
+/obj/machinery/computer/ship/disperser/military
+	name = "impulse cannon control"
+	caldigit = 2
+	coolinterval = 30 SECONDS
 
 /obj/machinery/computer/ship/disperser/Initialize()
 	. = ..()

--- a/code/modules/overmap/disperser/disperser_fire.dm
+++ b/code/modules/overmap/disperser/disperser_fire.dm
@@ -157,7 +157,15 @@
 		for(var/mob/living/L in charge)
 			to_chat(L, SPAN_DANGER("Your body shakes violently as the drop pod reaches it's destination."))
 	else
-		charge.fire(targetturf, strength, range)
+		var/shield_active_EM = FALSE
+		var/shield_active_KTC = FALSE
+		for(var/obj/machinery/power/shield_generator/S in SSmachines.machinery)
+			if(S.z in finaltarget.map_z)
+				if(S.running == SHIELD_RUNNING && S.check_flag(MODEFLAG_EM))
+					shield_active_EM = TRUE
+				if(S.running == SHIELD_RUNNING && S.check_flag(MODEFLAG_HYPERKINETIC))
+					shield_active_KTC = TRUE
+		charge.fire(targetturf, strength, range, shield_active_EM, shield_active_KTC)
 		qdel(charge)
 
 /obj/machinery/computer/ship/disperser/proc/handle_beam(turf/start, direction)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -230,8 +230,8 @@
 	color = "#673910"
 	touch_met = 50
 
-/datum/reagent/napalm/touch_turf(var/turf/T)
-	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
+/datum/reagent/napalm/touch_turf(var/turf/T, nologs=FALSE)
+	new /obj/effect/decal/cleanable/liquid_fuel(T, volume, nologs)
 	remove_self(volume)
 
 /datum/reagent/napalm/touch_mob(var/mob/living/L, var/amount)
@@ -523,27 +523,27 @@
 /datum/reagent/colored_hair_dye/red
 	name = "Red Hair Dye"
 	color = "#b33636"
-	
+
 /datum/reagent/colored_hair_dye/orange
 	name = "Orange Hair Dye"
 	color = "#b5772f"
-	
+
 /datum/reagent/colored_hair_dye/yellow
 	name = "Yellow Hair Dye"
 	color = "#a6a035"
-		
+
 /datum/reagent/colored_hair_dye/green
 	name = "Green Hair Dye"
 	color = "#61a834"
-	
+
 /datum/reagent/colored_hair_dye/blue
 	name = "Blue Hair Dye"
 	color = "#3470a8"
-	
+
 /datum/reagent/colored_hair_dye/purple
 	name = "Purple Hair Dye"
 	color = "#6d2d91"
-		
+
 /datum/reagent/colored_hair_dye/grey
 	name = "Grey Hair Dye"
 	color = "#696969"

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -219,11 +219,11 @@
 /area/ship/patrol/maintenance/atmos)
 "az" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/unary/tank/air,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/tank/air,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/patrol/maintenance/atmos)
 "aA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -237,8 +237,10 @@
 	frequency = 1442;
 	icon_state = "map_injector";
 	id = "co2_in";
-	pixel_y = 1;
 	use_power = 1
+	},
+/obj/effect/floor_decal/corner/black/half{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/patrol/maintenance/atmos)
@@ -256,25 +258,27 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/obj/machinery/air_sensor{
-	id_tag = "co2_sensor"
+/obj/effect/floor_decal/corner/black/half{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/patrol/maintenance/atmos)
 "aD" = (
+/obj/effect/floor_decal/corner/mauve/half{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1442;
 	icon_state = "map_injector";
 	id = "h2_in";
-	pixel_y = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/maintenance/atmos)
-"aE" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced/hydrogen,
 /area/ship/patrol/maintenance/atmos)
 "aF" = (
+/obj/effect/floor_decal/corner/mauve/half{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/ship/patrol/maintenance/atmos)
 "aG" = (
@@ -290,6 +294,9 @@
 	pressure_checks_default = 2;
 	pump_direction = 0;
 	use_power = 1
+	},
+/obj/effect/floor_decal/corner/mauve/half{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/ship/patrol/maintenance/atmos)
@@ -425,8 +432,8 @@
 	id = "o2_in";
 	use_power = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/corner/blue/half{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/ship/patrol/maintenance/atmos)
@@ -636,11 +643,8 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/obj/machinery/air_sensor{
-	id_tag = "o2_sensor"
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/corner/blue/half{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/ship/patrol/maintenance/atmos)
@@ -727,7 +731,6 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "bz" = (
-/obj/structure/closet/crate/internals/fuel,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
@@ -979,6 +982,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
+/obj/structure/closet/crate/internals/fuel,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "cc" = (
@@ -1244,11 +1248,8 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/machinery/air_sensor{
-	id_tag = "n2_sensor"
+/obj/effect/floor_decal/corner/red/half{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/ship/patrol/maintenance/atmos)
@@ -1713,16 +1714,13 @@
 	id = "n2_in";
 	use_power = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/effect/floor_decal/corner/red/half{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/ship/patrol/maintenance/atmos)
 "dk" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 1
 	},
@@ -1730,7 +1728,10 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/patrol/maintenance/atmos)
 "dl" = (
 /obj/structure/cable{
@@ -1881,11 +1882,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ship/patrol/crew/cargo)
 "dC" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/crew/cargo)
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "dD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2057,33 +2062,87 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/starboard)
 "dX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/maintenance/lower/starboard)
-"dY" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower/starboard)
-"dZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower/starboard)
-"ea" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25;
-	req_access = list("ACCESS_CAVALRY")
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "bridgep_lock";
+	name = "Bridge Lockdown blast doors"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/catwalk,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/paint/dark_gunmetal,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower/starboard)
+/area/ship/patrol/command/bridge)
+"dY" = (
+/obj/machinery/power/apc/critical{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 23
+	},
+/obj/structure/table/steel_reinforced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/photocopier/faxmachine{
+	send_access = list();
+	department = "Sol 5th Fleet Patrol Craft"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
+"dZ" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/button/blast_door{
+	desc = "A remote control-switch for the observation shutters";
+	id_tag = "bridgep_lock";
+	name = "Bridge Lockdown";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/button/blast_door{
+	desc = "A remote control-switch for the observation shutters";
+	id_tag = "sensorslockp";
+	name = "Sensors Protection Switch";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/button/alternate/door/bolts{
+	id_tag = "cannon";
+	name = "Impulse Cannon bolts";
+	pixel_x = 6;
+	pixel_y = 34;
+	req_access = list("ACCESS_CAVALRY_PILOT")
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
+"ea" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/ship/patrol/command/bridge)
 "eb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2270,16 +2329,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	req_access = list("ACCESS_CAVALRY")
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -2452,78 +2501,53 @@
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/dark_gunmetal,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "bridgep_lock";
+	name = "Bridge Lockdown blast doors"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/bridge)
 "eQ" = (
-/obj/machinery/computer/ship/engines{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/ship/sensors{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "eR" = (
-/obj/item/storage/secure/safe{
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the observation shutters";
-	id_tag = "sensorslockp";
-	name = "Sensors Protection Switch";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/obj/machinery/button/blast_door{
-	desc = "A remote control-switch for the observation shutters";
-	id_tag = "bridgep_lock";
-	name = "Bridge Lockdown";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/machinery/button/alternate/door/bolts{
-	id_tag = "cannon";
-	name = "Impulse Cannon bolts";
-	pixel_x = 6;
-	pixel_y = 34;
-	req_access = list("ACCESS_CAVALRY_COMMANDER")
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "top-right"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "eS" = (
-/obj/machinery/power/apc/critical{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "eT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/photocopier/faxmachine{
-	send_access = list();
-	department = "Sol 5th Fleet Patrol Craft"
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "eU" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen/fancy{
-	pixel_x = 3;
-	pixel_y = -1
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "bottom-left"
 	},
-/obj/structure/panic_button{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "eV" = (
 /obj/machinery/door/firedoor,
@@ -2532,9 +2556,14 @@
 	id_tag = "bridgep_lock";
 	name = "Bridge Lockdown blast doors"
 	},
-/obj/effect/wallframe_spawn/reinforced,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
 "eW" = (
 /obj/structure/cable/yellow{
@@ -2729,10 +2758,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/ship/helm{
-	dir = 4
+/obj/structure/table/steel_reinforced,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "fq" = (
 /obj/structure/cable{
@@ -2740,13 +2772,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "bottom-center"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "fr" = (
-/obj/machinery/hologram/holopad/longrange,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -2762,7 +2797,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8
+	},
 /obj/effect/overmap/visitable/ship/patrol,
+/obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "fs" = (
@@ -2774,6 +2816,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "top-center"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "ft" = (
@@ -2783,6 +2832,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2803,6 +2855,22 @@
 	name = "Bridge Lockdown blast doors"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/door/airlock/multi_tile/glass/command{
+	name = "Bridge"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
 "fv" = (
@@ -2814,11 +2882,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24;
+	req_access = list("ACCESS_CAVALRY")
 	},
-/obj/structure/bed/sofa/l/black{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2946,14 +3019,21 @@
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower/starboard)
 "fN" = (
-/obj/machinery/computer/ship/sensors{
-	dir = 4
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "fO" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "bottom-right"
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
@@ -2963,39 +3043,32 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/patrol/command/bridge)
-"fQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "center-right"
 	},
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
-"fR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"fQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "top-left"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "fS" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	id_tag = "bridgep_lock";
 	name = "Bridge Lockdown blast doors"
 	},
-/obj/machinery/door/airlock/multi_tile/glass/command{
-	name = "Bridge"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/cable,
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/floor/plating,
 /area/ship/patrol/command/bridge)
 "fT" = (
 /obj/structure/cable{
@@ -3004,15 +3077,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	req_access = list("ACCESS_CAVALRY")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/padded/black{
+	dir = 1
 	},
-/obj/structure/bed/sofa/r/black{
+/obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3046,11 +3119,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/maintenance/lower/starboard)
-"fX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/wall,
-/area/ship/patrol/command/hangar)
 "fY" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -3172,19 +3240,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/ship/patrol/crew/hallway/lower/starboard)
 "gm" = (
-/obj/machinery/pointdefense_control{
-	initial_id_tag = "patrol_pd"
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -20
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22;
-	req_access = list("ACCESS_CAVALRY")
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue/three_quarters,
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "gn" = (
 /obj/structure/cable{
@@ -3197,27 +3263,35 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "go" = (
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "gp" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24;
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -20
+/obj/machinery/pointdefense_control{
+	initial_id_tag = "patrol_pd"
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "gr" = (
 /obj/structure/cable{
@@ -3227,9 +3301,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
@@ -3417,11 +3490,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass/command{
-	id_tag = "bridgep";
-	name = "Bridge";
-	secured_wires = 1
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/patrol/command/bridge)
@@ -6124,10 +6192,10 @@
 /area/ship/patrol/crew/hallway/lower/port)
 "lA" = (
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/multi_tile/glass/sol{
 	name = "Troops Cryo"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/barracks)
 "lB" = (
@@ -8396,16 +8464,30 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/command/cannon)
 "rx" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "rI" = (
-/obj/machinery/vending/coffee{
-	name = "Better Hot Drinks machine";
-	prices = list()
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/ship/helm{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "rL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8598,6 +8680,15 @@
 /obj/machinery/door/window/brigdoor/northright,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/command/cannon)
+"xR" = (
+/obj/structure/panic_button{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "ya" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8632,6 +8723,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
+"zq" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "zJ" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8860,9 +8957,11 @@
 /area/ship/patrol/medbay)
 "Gb" = (
 /obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced,
-/obj/effect/paint/dark_gunmetal,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/multi_tile/glass/command{
+	name = "Bridge"
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/ship/patrol/command/bridge)
 "Gj" = (
 /obj/machinery/atmospherics/unary/heater{
@@ -8881,6 +8980,23 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/cannon)
+"GF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/ship/engines{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 24;
+	req_access = list("ACCESS_CAVALRY")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "GP" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/sleeper{
@@ -8977,6 +9093,17 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/crew/cargo)
+"JZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/folder/blue,
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "Ks" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9024,6 +9151,19 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
+"KQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/icarus_scglogo{
+	dir = 8;
+	icon_state = "center-left"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "Lm" = (
 /obj/effect/paint/red,
 /turf/simulated/wall/r_titanium,
@@ -9223,12 +9363,6 @@
 "Qe" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/command/cannon)
-"Qt" = (
-/obj/machinery/air_sensor{
-	id_tag = "tox_sensor"
-	},
-/turf/simulated/floor/reinforced/hydrogen,
-/area/ship/patrol/maintenance/atmos)
 "QH" = (
 /obj/effect/paint/red,
 /obj/structure/sign/warning/hot_exhaust,
@@ -9293,6 +9427,13 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
+"RA" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "RG" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/porta_turret{
@@ -9338,8 +9479,15 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/atmos)
 "UL" = (
-/obj/structure/flora/pottedplant/stoutbush,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/structure/bed/chair/padded/black,
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/patrol/command/bridge)
 "Vb" = (
 /obj/effect/paint/dark_gunmetal,
@@ -9452,6 +9600,22 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
+"Ww" = (
+/obj/effect/paint/dark_gunmetal,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id_tag = "bridgep_lock";
+	name = "Bridge Lockdown blast doors"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/patrol/command/bridge)
 "WX" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/sign/warning/vent_port,
@@ -9480,12 +9644,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/barracks/armory)
 "Xv" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
+/obj/structure/table/steel_reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/pen/fancy{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/storage/secure/safe{
+	pixel_y = 24;
+	pixel_x = 3
+	},
+/obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/lower/starboard)
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "Xx" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 4
@@ -9553,6 +9730,30 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"YP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
+"YU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/patrol/command/bridge)
 "Zl" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -9568,6 +9769,14 @@
 /obj/structure/sign/warning/hot_exhaust,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
+"Zr" = (
+/obj/machinery/vending/coffee{
+	name = "Better Hot Drinks machine";
+	prices = list()
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/ship/patrol/command/bridge)
 "ZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16720,9 +16929,9 @@ bh
 bM
 cw
 dc
-dz
-dX
+wa
 ex
+dX
 eP
 fo
 ex
@@ -16842,9 +17051,9 @@ bi
 bN
 HY
 dd
-dC
-dY
-ex
+wa
+GF
+rI
 eQ
 fp
 fN
@@ -16964,10 +17173,10 @@ bj
 bO
 cx
 de
-bj
-dZ
-ex
-eR
+wN
+xR
+eS
+eU
 fq
 fO
 gm
@@ -17086,10 +17295,10 @@ bk
 bP
 cy
 df
-bj
+wN
 dY
-ex
-eS
+JZ
+KQ
 fr
 fP
 gn
@@ -17208,12 +17417,12 @@ bl
 bQ
 cz
 dg
-bj
+wN
 dZ
-ex
-eT
-fs
+YP
 fQ
+fs
+eR
 rx
 gI
 hr
@@ -17330,12 +17539,12 @@ bm
 bR
 cA
 dh
-bj
+wN
 Xv
-ex
-eU
+RA
+go
 ft
-fR
+zq
 gp
 ex
 ht
@@ -17452,9 +17661,9 @@ bn
 bS
 cB
 cB
-bj
-dZ
+wN
 ex
+Ww
 eV
 fu
 fS
@@ -17575,12 +17784,12 @@ wN
 wN
 wN
 wN
-dZ
-ey
-rI
-ft
-fR
-go
+Zr
+eT
+eT
+YU
+eT
+eT
 Gb
 hv
 im
@@ -17698,7 +17907,7 @@ cC
 di
 Uk
 ea
-ey
+dC
 UL
 fv
 fT
@@ -17819,7 +18028,7 @@ ba
 bp
 bp
 Uk
-dX
+ey
 ey
 ey
 ey
@@ -18311,7 +18520,7 @@ Uk
 Uk
 fa
 fz
-fX
+fa
 fa
 fa
 hB
@@ -19032,7 +19241,7 @@ aa
 aa
 aj
 Uk
-aE
+aF
 bc
 bz
 cc
@@ -19154,7 +19363,7 @@ aa
 aa
 aj
 Uk
-Qt
+aF
 bc
 bA
 cd

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -2091,17 +2091,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "ec" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
@@ -2209,20 +2204,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/engine/starboard)
 "eo" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "ep" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/missile/antispace,
+/obj/structure/ship_munition/disperser_charge/emp/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "eq" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -2230,14 +2225,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/ship_munition/disperser_charge/emp/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
-"er" = (
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/outline/green,
-/obj/structure/missile/diffusive,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "es" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -2386,25 +2376,15 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "eI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "eJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2415,7 +2395,7 @@
 	},
 /obj/item/storage/bible,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "eK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -2500,8 +2480,8 @@
 	pixel_y = 24
 	},
 /obj/machinery/button/alternate/door/bolts{
-	id_tag = "miss_pod";
-	name = "Missile Section Lock";
+	id_tag = "cannon";
+	name = "Impulse Cannon bolts";
 	pixel_x = 6;
 	pixel_y = 34;
 	req_access = list("ACCESS_CAVALRY_COMMANDER")
@@ -2530,21 +2510,18 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/panic_button{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
 "eU" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/structure/table/steel_reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/pen/fancy{
 	pixel_x = 3;
 	pixel_y = -1
+	},
+/obj/structure/panic_button{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
@@ -3146,13 +3123,14 @@
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/ship_munition/disperser_charge/explosive/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "gh" = (
 /obj/effect/paint/meatstation/lab,
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "gi" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -3234,6 +3212,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24;
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -20
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
@@ -3361,7 +3343,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/crew/hallway/lower/fore)
 "gE" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3571,8 +3553,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/highsecurity/bolted{
-	id_tag = "miss_pod";
-	name = "Missile Section"
+	id_tag = "cannon";
+	name = "Impulse Cannon"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3581,7 +3563,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "gY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3592,36 +3574,44 @@
 	req_access = list("ACCESS_CAVALRY")
 	},
 /obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "gZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/missile/antispace,
 /obj/structure/sign/warning/moving_parts{
 	dir = 4;
 	pixel_x = -34
 	},
+/obj/structure/ship_munition/disperser_charge/explosive/military,
+/obj/structure/ship_munition/disperser_charge/explosive/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "ha" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/ship_munition/disperser_charge/explosive/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hc" = (
-/obj/effect/floor_decal/industrial/outline/green,
-/obj/structure/missile/diffusive,
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/paint/dark_gunmetal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3630,12 +3620,13 @@
 	dir = 6
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hg" = (
 /obj/effect/floor_decal/corner/red,
 /obj/structure/cable{
@@ -3875,36 +3866,39 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/command/hangar)
 "hL" = (
-/obj/machinery/mass_driver{
-	id_tag = "patmissile";
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light/small/red{
+	name = "light fixture";
+	dir = 1
+	},
+/obj/machinery/disperser/middle{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hM" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hN" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "bsap"
 	},
-/obj/machinery/light/small/red{
-	name = "light fixture"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/disperser/back{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hO" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -3917,11 +3911,16 @@
 	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "bsap_space";
-	name = "Missile Compartament Hatch";
+	name = "Cannon Compartment Hatch";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/patrol/command/cannon)
 "hP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3933,8 +3932,13 @@
 	dir = 8;
 	id = "bsap"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/patrol/command/cannon)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3944,7 +3948,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hR" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -3959,7 +3963,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3977,11 +3981,11 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/highsecurity/bolted{
-	id_tag = "miss_pod";
-	name = "Missile Section"
+	id_tag = "cannon";
+	name = "Impulse Cannon"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3998,7 +4002,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "hU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4015,7 +4019,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/crew/hallway/lower/fore)
 "hV" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -4574,12 +4578,12 @@
 /obj/effect/paint/meatstation/lab,
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "iE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4587,15 +4591,15 @@
 	dir = 4;
 	pixel_x = -34
 	},
-/obj/structure/missile/he,
+/obj/structure/ship_munition/disperser_charge/emp/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "iF" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "iG" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall,
@@ -8347,7 +8351,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "pO" = (
 /obj/effect/shuttle_landmark/nav_patrol/nav3,
 /turf/space,
@@ -8360,17 +8364,24 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "qG" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "rs" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/turf/space,
-/area/space)
+/obj/machinery/shield_diffuser,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "bsap_space";
+	name = "Cannon Compartment Hatch"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/patrol/command/cannon)
 "rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/conveyor_switch{
@@ -8383,7 +8394,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "rx" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
@@ -8404,17 +8415,11 @@
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "rQ" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -8526,27 +8531,20 @@
 /turf/simulated/wall/ocp_wall,
 /area/ship/patrol/engineering/fussion/control)
 "vz" = (
-/obj/machinery/computer/ship/missiles{
+/obj/machinery/computer/ship/disperser/military{
 	dir = 4
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/cannon)
+"vR" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
-"vR" = (
-/obj/structure/railing/mapped,
-/obj/structure/missile/he,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "wa" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
@@ -8557,7 +8555,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "wk" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1442;
@@ -8572,21 +8570,22 @@
 	pixel_y = 26
 	},
 /obj/structure/bed/chair/padded/black,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "wN" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/dock)
 "wO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/cannon)
 "xr" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/plating,
@@ -8595,18 +8594,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
+/obj/machinery/door/window/brigdoor/northright,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "ya" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8617,18 +8608,21 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/command/hangar)
 "ye" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/cannon)
 "yr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sign/warning/bomb_range{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "zp" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8675,9 +8669,13 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/lower)
 "Bz" = (
-/obj/effect/floor_decal/industrial/outline/green,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "BI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8685,21 +8683,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "BY" = (
-/obj/effect/paint/dark_gunmetal,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/ship_munition/disperser_charge/emp/military,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/command/cannon)
 "Cb" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -8736,13 +8725,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Cy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8752,7 +8736,7 @@
 	pixel_x = -34
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "CI" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -8792,8 +8776,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/patrol/command/cannon)
 "DU" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/sign/solgov,
@@ -8848,7 +8837,6 @@
 /area/ship/patrol/maintenance/engine/port)
 "FI" = (
 /obj/structure/lattice,
-/obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/cable{
 	d1 = 4;
@@ -8865,7 +8853,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "FW" = (
 /obj/effect/paint/meatstation/lab,
 /turf/simulated/wall/r_wall,
@@ -8884,10 +8872,15 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/atmos)
 "GD" = (
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/outline/green,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/obj/effect/paint/dark_gunmetal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/cannon)
 "GP" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/sleeper{
@@ -8917,14 +8910,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "HY" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 8
@@ -8939,10 +8927,14 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
 "IG" = (
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/obj/effect/paint/dark_gunmetal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/cannon)
 "IW" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -8995,7 +8987,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Kv" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -9051,14 +9043,8 @@
 /obj/structure/bed/chair/office/comfy/blue{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "LN" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -9086,8 +9072,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/ship_munition/disperser_charge/explosive/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Mm" = (
 /obj/machinery/pointdefense{
 	initial_id_tag = "patrol_pd"
@@ -9114,13 +9101,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "MR" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/machinery/atmospherics/binary/pump/on{
@@ -9163,13 +9145,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Op" = (
 /obj/effect/paint/meatstation/lab,
 /obj/structure/cable{
@@ -9222,8 +9199,13 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_CAVALRY")
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "PX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -9240,7 +9222,7 @@
 /area/ship/patrol/crew/hallway/lower)
 "Qe" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Qt" = (
 /obj/machinery/air_sensor{
 	id_tag = "tox_sensor"
@@ -9262,13 +9244,13 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "QP" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/missile/he,
+/obj/structure/ship_munition/disperser_charge/explosive/military,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Rb" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -9284,19 +9266,11 @@
 /turf/simulated/floor,
 /area/ship/patrol/engineering/fussion/control)
 "Rk" = (
-/obj/machinery/button/mass_driver{
-	id_tag = "patmissile";
-	pixel_x = 8;
-	req_access = list("ACCESS_CAVALRY");
-	pixel_y = 35;
-	name = "Missile Launch Button";
-	desc = "Send this deadly thing!"
-	},
 /obj/machinery/button/blast_door{
 	pixel_x = 8;
 	pixel_y = 25;
 	id_tag = "bsap_space";
-	name = "Launch-ready Blast Door"
+	name = "Fire-ready Blast Door"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9305,8 +9279,13 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/hand_labeler,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Rs" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4
@@ -9345,18 +9324,15 @@
 /turf/space,
 /area/space)
 "SV" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "bsap_space";
-	name = "Missile Compartament Hatch"
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/disperser/front{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced/airless,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Uk" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
@@ -9375,16 +9351,22 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
 "Vf" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 4;
 	pixel_x = -34;
 	pixel_y = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Vm" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 4
@@ -9393,7 +9375,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Vq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -9477,14 +9459,12 @@
 /area/ship/patrol/engineering/fussion/control)
 "Xc" = (
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/turf/space,
-/area/space)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/command/cannon)
 "Xg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -9492,7 +9472,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "Xj" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 5
@@ -9528,13 +9508,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/command/missiles)
+/area/ship/patrol/command/cannon)
 "XJ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -13824,10 +13799,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+qG
+qG
+rs
+qG
 aa
 aa
 aa
@@ -13943,11 +13918,11 @@ aa
 aa
 aa
 eF
-sZ
-rs
+PF
+PF
 qG
-gh
 qG
+hM
 SV
 qG
 qG
@@ -14064,7 +14039,7 @@ aa
 aa
 aa
 aa
-Xc
+ty
 qG
 gh
 gh
@@ -14309,8 +14284,8 @@ aa
 aa
 qG
 iD
-hM
-hM
+GD
+IG
 hM
 hM
 hM
@@ -14430,7 +14405,7 @@ aa
 aa
 qG
 qG
-hd
+hM
 hM
 Rk
 rt
@@ -14441,7 +14416,7 @@ iE
 wf
 Cy
 hM
-hd
+FP
 gh
 FW
 aa
@@ -14552,18 +14527,18 @@ qG
 qG
 qG
 hM
-hd
+hM
 hM
 wC
 Qe
 Qe
 ha
 hP
-ha
+BY
 Xg
 gY
-hM
-FP
+GD
+hd
 hM
 FW
 FW
@@ -14674,7 +14649,7 @@ qG
 hM
 hM
 hM
-hd
+hM
 hM
 PV
 Qe
@@ -14796,10 +14771,10 @@ hM
 hM
 hM
 hM
-BY
 hM
-Qe
-Qe
+hM
+Xc
+vR
 hf
 QL
 hR
@@ -15158,14 +15133,14 @@ al
 tn
 tn
 cl
+tn
+tn
 hM
-hM
-er
 ep
 ep
 QP
-vR
-vR
+QP
+QP
 hM
 hM
 hS
@@ -15282,16 +15257,16 @@ bD
 cm
 cR
 tn
-GD
+hM
 eq
-IG
+ep
 gg
 LU
 gg
 hM
 gD
 hU
-hM
+jk
 jn
 jS
 kp

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -363,10 +363,12 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "aM" = (
-/obj/structure/table/rack,
+/mob/living/exosuit/premade/powerloader/old,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/storage/toolbox/mechanical,
-/obj/random/junk,
+/obj/machinery/mech_recharger,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "aN" = (
@@ -1016,20 +1018,21 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "cm" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/machinery/button/blast_door{
 	id_tag = "ofd_storagep";
 	name = "OFD Ammunition Storage Shutters";
@@ -1037,22 +1040,71 @@
 	pixel_y = 24;
 	req_access = list("access_away_cavalry")
 	},
-/obj/structure/missile/he,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "co" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "cp" = (
-/obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/missile/he,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "cr" = (
 /obj/machinery/light,
@@ -1394,22 +1446,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/catwalk,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "cN" = (
@@ -1424,27 +1465,23 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "cO" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
@@ -1618,26 +1655,39 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "dh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/mapped{
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/patrol/maintenance/upper/aft)
+"di" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/table/rack,
-/obj/item/missile_equipment/thruster/planet,
-/obj/item/missile_equipment/thruster/planet,
-/obj/item/missile_equipment/thruster/hunter,
-/obj/item/missile_equipment/thruster/hunter,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/maintenance/upper/munition)
-"di" = (
-/obj/effect/floor_decal/industrial/outline/green,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25;
-	req_access = list("ACCESS_CAVALRY")
-	},
-/obj/structure/missile/diffusive,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "dj" = (
 /obj/effect/paint/meatstation/lab,
@@ -2084,9 +2134,8 @@
 	pixel_x = 24;
 	req_access = list("ACCESS_CAVALRY")
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "ee" = (
 /obj/structure/cable{
@@ -2504,13 +2553,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/crew/brig/emergency_armory)
 "eS" = (
-/obj/structure/railing/mapped{
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/missile,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/maintenance/upper/aft)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/patrol/maintenance/upper/munition)
 "eV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2571,6 +2626,9 @@
 	name = "Better Robust Softdrinks";
 	prices = list()
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "fb" = (
@@ -2580,10 +2638,6 @@
 	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
@@ -2615,6 +2669,9 @@
 	prices = list()
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "ff" = (
@@ -2624,9 +2681,6 @@
 /obj/machinery/vending/cigarette{
 	name = "Better Cigarette machine";
 	prices = list()
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
@@ -2909,20 +2963,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "fE" = (
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25;
+	req_access = list("ACCESS_CAVALRY")
 	},
-/obj/structure/table/rack,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/obj/item/missile_equipment/autoarm,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/upper/aft)
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/ship_munition/disperser_charge/emp/military,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/maintenance/upper/munition)
 "fF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3642,6 +3691,9 @@
 /obj/item/reagent_containers/food/snacks/can,
 /obj/item/material/canknife,
 /obj/item/material/canknife,
+/obj/machinery/vending/fitness{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
 "gU" = (
@@ -3898,9 +3950,9 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/machinery/vending/fitness{
-	dir = 1
+	dir = 1;
+	prices = list()
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
@@ -3915,6 +3967,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/storage/box/cups,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "hs" = (
@@ -3926,10 +3979,6 @@
 	pixel_x = 22
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/crew/kitchen)
 "ht" = (
@@ -4201,8 +4250,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "mn" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -4210,18 +4259,33 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/aft)
 "ms" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 23;
 	req_access = list("ACCESS_CAVALRY")
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "mv" = (
 /obj/structure/catwalk,
@@ -4308,10 +4372,9 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper)
 "oM" = (
-/obj/structure/railing/mapped,
-/obj/structure/plushie/drone,
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/upper/aft)
+/obj/effect/paint/dark_gunmetal,
+/turf/simulated/wall,
+/area/ship/patrol/maintenance/upper/munition)
 "pk" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4323,18 +4386,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "pl" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/mapped,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/aft)
 "pm" = (
 /obj/machinery/light/small,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/missile,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "pp" = (
@@ -4349,22 +4408,15 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper)
 "pu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id_tag = "ofd_storagep";
+	name = "Missile Storage Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/upper/aft)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/maintenance/upper/munition)
 "qe" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -4375,7 +4427,9 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/port)
 "qG" = (
-/obj/effect/floor_decal/industrial/outline/green,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/ship_munition/disperser_charge/emp/military,
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "qJ" = (
@@ -4458,19 +4512,15 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "st" = (
-/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4515,13 +4565,15 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
 "tE" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/missile/antispace,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "tL" = (
 /obj/structure/railing/mapped{
@@ -4632,6 +4684,19 @@
 /obj/structure/lattice,
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"wd" = (
+/obj/machinery/pointdefense{
+	initial_id_tag = "patrol_pd"
+	},
+/obj/machinery/pointdefense{
+	initial_id_tag = "patrol_pd"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "wv" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -4645,14 +4710,7 @@
 	dir = 1
 	},
 /obj/structure/table/rack,
-/obj/item/missile_equipment/payload/emp,
-/obj/item/missile_equipment/payload/emp,
-/obj/item/missile_equipment/payload/emp,
-/obj/item/missile_equipment/payload/emp,
-/obj/item/missile_equipment/payload/explosive,
-/obj/item/missile_equipment/payload/explosive,
-/obj/item/missile_equipment/payload/explosive,
-/obj/item/missile_equipment/payload/explosive,
+/obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "wB" = (
@@ -4707,6 +4765,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /turf/simulated/floor,
 /area/ship/patrol/maintenance/upper/aft)
@@ -4735,71 +4796,38 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/upper/munition)
 "zz" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/patrol/maintenance/upper/munition)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/ship/patrol/maintenance/upper/aft)
 "zO" = (
 /obj/effect/paint/dark_gunmetal,
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/upper/starboard)
 "zP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/ship_munition/disperser_charge/explosive/military,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "zX" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/ship_munition/disperser_charge/emp/military,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "Ae" = (
 /obj/structure/catwalk,
@@ -4857,10 +4885,9 @@
 /area/ship/patrol/maintenance/upper/starboard)
 "Bt" = (
 /obj/item/stack/cable_coil/yellow,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/mech_component/manipulators,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "Bv" = (
 /obj/random/trash,
@@ -4879,15 +4906,30 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/port)
 "CA" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/missile/he,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "CW" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/table/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/random/junk,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "Dj" = (
 /obj/effect/paint/dark_gunmetal,
@@ -4899,18 +4941,12 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/upper)
 "Du" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Missile Storage"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "Dx" = (
@@ -4963,14 +4999,19 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
 "Fp" = (
-/obj/machinery/mech_recharger,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/mob/living/exosuit/premade/powerloader/old,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/maintenance/upper/aft)
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/entertainment{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/ship/patrol/crew/kitchen)
 "FT" = (
 /obj/machinery/pointdefense{
 	initial_id_tag = "patrol_pd"
@@ -4993,54 +5034,37 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
 "GH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id_tag = "ofd_storagep";
+	name = "Missile Storage Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/upper/aft)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/maintenance/upper/munition)
 "GS" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/structure/ship_munition/disperser_charge/explosive/military,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "GW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/ship_munition/disperser_charge/fire/military,
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/munition)
 "Hm" = (
 /obj/structure/bed/chair/wood/maple{
@@ -5086,6 +5110,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "Ix" = (
@@ -5110,8 +5135,8 @@
 /area/ship/patrol/maintenance/upper/waste)
 "IW" = (
 /obj/structure/mattress,
-/obj/random/maintenance/solgov/clean,
 /obj/machinery/light/small,
+/obj/item/toy/plushie/dakimakura,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "Jd" = (
@@ -5311,11 +5336,6 @@
 /obj/random/closet,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/port)
-"OH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/mech_component/manipulators,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/patrol/maintenance/upper/aft)
 "OL" = (
 /obj/effect/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -5357,12 +5377,7 @@
 	dir = 1
 	},
 /obj/structure/table/rack,
-/obj/item/missile_equipment/thruster,
-/obj/item/missile_equipment/thruster,
-/obj/item/missile_equipment/thruster,
-/obj/item/missile_equipment/thruster/point,
-/obj/item/missile_equipment/thruster/point,
-/obj/item/missile_equipment/thruster/point,
+/obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "PK" = (
@@ -5407,12 +5422,12 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
 "RI" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/table/rack,
+/obj/random/junk,
+/turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "RL" = (
 /obj/structure/table/rack,
@@ -5456,24 +5471,29 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
 "Tq" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Missile Storage"
 	},
-/obj/structure/railing/mapped,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/ship/patrol/maintenance/upper/aft)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/patrol/maintenance/upper/munition)
 "TK" = (
 /obj/random/closet,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
 "TN" = (
-/obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "TP" = (
@@ -5675,24 +5695,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/maintenance/upper/aft)
 "YP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/structure/catwalk,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/aft)
 "YZ" = (
@@ -9933,10 +9939,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -10057,7 +10063,7 @@ aa
 ab
 ab
 ab
-ab
+wd
 ab
 ab
 aa
@@ -10179,7 +10185,7 @@ ab
 ab
 ab
 ab
-FT
+lD
 ab
 ab
 ab
@@ -12993,7 +12999,7 @@ fP
 gf
 gv
 gK
-gK
+Fp
 fg
 Mb
 hC
@@ -15551,7 +15557,7 @@ rJ
 rJ
 rJ
 rJ
-ay
+wx
 TX
 TX
 ad
@@ -15664,16 +15670,16 @@ ad
 TX
 TX
 mn
+dh
 TN
-GH
 TN
-RI
+TN
 ed
 pl
 Uu
 rJ
 ka
-ay
+RI
 TX
 TX
 ad
@@ -15786,11 +15792,11 @@ ad
 TX
 TX
 bI
-pk
+GH
 cN
 pk
-bI
-ax
+pu
+oM
 rH
 Dz
 YI
@@ -15909,10 +15915,10 @@ ad
 TX
 bJ
 cm
-zz
-dh
+GS
+GS
+zP
 bJ
-aM
 CW
 Aq
 rJ
@@ -16033,9 +16039,9 @@ bJ
 co
 st
 tE
+eS
 bJ
-Fp
-CW
+aM
 Aq
 rJ
 IW
@@ -16153,14 +16159,14 @@ ad
 TX
 bJ
 CA
-zz
 GS
+GS
+zP
 bJ
-OH
 Bt
 Aq
 rJ
-fE
+wx
 TX
 TX
 ad
@@ -16275,10 +16281,10 @@ ad
 ad
 bJ
 ms
-zP
+GW
 GW
 Du
-pu
+bJ
 YP
 sD
 rJ
@@ -16399,11 +16405,11 @@ sL
 cp
 cO
 di
-bJ
+di
 Tq
-cj
-eS
-eS
+zz
+rJ
+rJ
 pm
 JD
 AF
@@ -16518,14 +16524,14 @@ aa
 ab
 ad
 bK
-co
+qG
 zX
 qG
-bI
-oM
+fE
+bJ
 xT
 ma
-In
+dg
 In
 dD
 ad
@@ -16644,7 +16650,7 @@ bJ
 bJ
 bJ
 bJ
-Mn
+oM
 vK
 Mn
 Mn

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1035,7 +1035,7 @@
 "cm" = (
 /obj/machinery/button/blast_door{
 	id_tag = "ofd_storagep";
-	name = "OFD Ammunition Storage Shutters";
+	name = "Ammunition Storage Shutters";
 	pixel_x = -6;
 	pixel_y = 24;
 	req_access = list("access_away_cavalry")
@@ -1692,6 +1692,9 @@
 "dj" = (
 /obj/effect/paint/meatstation/lab,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	id_tag = "abandoned_bar"
+	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper)
 "dk" = (
@@ -1823,7 +1826,7 @@
 	name = "Desk Shutters Control";
 	pixel_x = -24;
 	pixel_y = 11;
-	req_access = list("ACCESS_CAVALRY_COMMANDER")
+	req_access = list("ACCESS_CAVALRY_EMERG_ARMORY")
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -1875,6 +1878,10 @@
 "dF" = (
 /obj/structure/bed/chair/wood/maple{
 	dir = 8
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "abandoned_bar";
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/ship/patrol/maintenance/upper)
@@ -2550,6 +2557,10 @@
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list("ACCESS_CAVALRY")
 	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/crew/brig/emergency_armory)
 "eS" = (
@@ -4838,6 +4849,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/starboard)
+"Ao" = (
+/obj/effect/paint/meatstation/lab,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "abandoned_bar"
+	},
+/turf/simulated/floor/plating,
+/area/ship/patrol/maintenance/upper)
 "Aq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -5639,6 +5659,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "abandoned_bar"
 	},
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper)
@@ -10794,9 +10818,9 @@ vY
 ab
 ab
 ae
-dj
+Ao
 Xb
-dj
+Ao
 ae
 ab
 ab

--- a/maps/away_inf/sentinel/sentinel_areas.dm
+++ b/maps/away_inf/sentinel/sentinel_areas.dm
@@ -77,9 +77,9 @@
 	req_access = list(access_away_cavalry)
 
 /area/ship/patrol/crew/brig/emergency_armory
-	name = "\improper Emergency Armory"
+	name = "Emergency Armory"
 	icon_state = "locker"
-	req_access = list(access_away_cavalry, access_away_cavalry_commander)
+	req_access = list(access_away_cavalry, access_away_cavalry_fleet_armory)
 
 /area/ship/patrol/engineering/hallway
 	name = "\improper Engineering Hallway"

--- a/maps/away_inf/sentinel/sentinel_areas.dm
+++ b/maps/away_inf/sentinel/sentinel_areas.dm
@@ -177,7 +177,7 @@
 	req_access = list(access_away_cavalry)
 
 /area/ship/patrol/maintenance/upper/munition
-	name = "\improper Missile Storage"
+	name = "\improper Ammunition Storage"
 	req_access = list(access_away_cavalry)
 
 /area/ship/patrol/maintenance/upper/waste
@@ -223,8 +223,8 @@
 	icon_state = "purple"
 	req_access = list(access_away_cavalry)
 
-/area/ship/patrol/command/missiles
-	name = "\improper Missile Section"
+/area/ship/patrol/command/cannon
+	name = "\improper Impulse Cannon"
 	icon_state = "yellow"
 	req_access = list(access_away_cavalry)
 

--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -41,47 +41,11 @@
  */
 
 /var/const/access_away_cavalry = "ACCESS_CAVALRY"
+/var/const/access_away_cavalry_fleet_armory = "ACCESS_CAVALRY_EMERG_ARMORY"
 /var/const/access_away_cavalry_ops = "ACCESS_CAVALRY_OPS"
+/var/const/access_away_cavalry_pilot = "ACCESS_CAVALRY_PILOT"
 /var/const/access_away_cavalry_captain = "ACCESS_CAVALRY_CAPTAIN"
 /var/const/access_away_cavalry_commander = "ACCESS_CAVALRY_COMMANDER"
-
-/datum/access/access_away_cavalry_patrol
-	id = access_away_cavalry
-	desc = "SPS Main"
-	region = ACCESS_REGION_NONE
-
-/datum/access/access_away_cavalry_ops
-	id = access_away_cavalry_ops
-	desc = "SPS Army"
-	region = ACCESS_REGION_NONE
-
-/datum/access/access_away_cavalry_captain
-	id = access_away_cavalry_captain
-	desc = "SPS Captain"
-	region = ACCESS_REGION_NONE
-
-/datum/access/access_away_patrol_commander
-	id = access_away_cavalry_commander
-	desc = "SPS Commander"
-	region = ACCESS_REGION_NONE
-
-/obj/item/card/id/awaycavalry/fleet
-	color = COLOR_GRAY40
-	detail_color = "#447ab1"
-	access = list(access_away_cavalry)
-
-/obj/item/card/id/awaycavalry/ops
-	color = "#b10309c2"
-	detail_color = "#000000"
-	access = list(access_away_cavalry, access_away_cavalry_ops)
-
-/obj/item/card/id/awaycavalry/ops/captain
-	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_captain)
-	extra_details = list("goldstripe")
-
-/obj/item/card/id/awaycavalry/fleet/commander
-	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_commander)
-	extra_details = list("goldstripe")
 
 /* JOBS
  * =======
@@ -111,7 +75,6 @@
 					 SKILL_HAULING = SKILL_BASIC,
 					 SKILL_MEDICAL = SKILL_BASIC,
 					 SKILL_EVA = SKILL_BASIC)
-	access = list(access_away_cavalry, access_away_cavalry_ops)
 
 /datum/job/submap/patrol/captain
 	title = "Army SCGSO Leader"
@@ -137,7 +100,6 @@
 					 SKILL_HAULING = SKILL_BASIC,
 					 SKILL_MEDICAL = SKILL_BASIC,
 					 SKILL_EVA = SKILL_BASIC)
-	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_captain)
 
 /datum/job/submap/patrol/commander
 	title = "Fleet Commander"
@@ -161,7 +123,6 @@
 					 SKILL_MEDICAL = SKILL_BASIC,
 					 SKILL_PILOT = SKILL_ADEPT,
 					 SKILL_EVA = SKILL_BASIC)
-	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_commander)
 
 /datum/job/submap/patrol/pilot1
 	title = "Fleet Pilot"
@@ -185,7 +146,6 @@
 					 SKILL_MEDICAL = SKILL_BASIC,
 					 SKILL_PILOT = SKILL_ADEPT,
 					 SKILL_EVA = SKILL_BASIC)
-	access = list(access_away_cavalry)
 
 /datum/job/submap/patrol/surgeon
 	title = "Fleet Corpsman"
@@ -200,10 +160,10 @@
 	info = "Вы просыпаетесь и выходите из криосна, ощущая прохладный воздух на своём лице, а также лёгкую тошноту. \
 	Являясь одним из членов экипажа патрульного корабля 5-го флота ЦПСС, ваша задача состоит в медицинской поддержке экипажа. \
 	\
-	Хоть вы и являетесь офицером, в ваши обязанности НЕ входит командование экипажем - это всего лишь показатель вашего профессионализма в медицинской сфере. \
-	\
 	 Вам крайне нежелательно приближаться к кораблям и станциям с опозновательными знаками без разрешения от командования группировкой. \
-	 Исключением являются те ситуации, когда вы терпите бедствие или на вашем судне аварийная ситуация."
+	 Исключением являются те ситуации, когда вы терпите бедствие или на вашем судне аварийная ситуация.<br>\
+	\
+	 Хоть вы и являетесь офицером, в ваши обязанности НЕ входит командование экипажем - это всего лишь показатель вашего профессионализма в медицинской сфере."
 	min_skill = list(SKILL_COMBAT  = SKILL_BASIC,
 					 SKILL_WEAPONS = SKILL_BASIC,
 					 SKILL_HAULING = SKILL_ADEPT,
@@ -211,7 +171,6 @@
 					 SKILL_ANATOMY = SKILL_BASIC,
 					 SKILL_CHEMISTRY = SKILL_BASIC,
 					 SKILL_EVA = SKILL_BASIC)
-	access = list(access_away_cavalry)
 
 /datum/job/submap/patrol/engineer
 	title = "Fleet Technician"
@@ -238,7 +197,6 @@
 					 SKILL_ATMOS  = SKILL_BASIC,
 					 SKILL_ENGINES = SKILL_ADEPT,
 					 SKILL_DEVICES = SKILL_BASIC)
-	access = list(access_away_cavalry)
 
 
 /* BRANCH & RANKS
@@ -404,6 +362,7 @@
 	head = /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/officer/pilot1/away_solpatrol
 	belt = /obj/item/storage/belt/holster/security/tactical/away_solpatrol
+	id_types = list(/obj/item/card/id/awaycavalry/fleet/pilot)
 	gloves = /obj/item/clothing/gloves/thick/duty/rivalgloves
 
 /decl/hierarchy/outfit/job/patrol/fleet_command

--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -6,22 +6,31 @@
 /obj/item/card/id/awaycavalry/ops
 	desc = "An identification card issued to SolGov crewmembers aboard the Sol Patrol Craft."
 	icon_state = "base"
+	color = "#b10309c2"
+	detail_color = "#000000"
 	access = list(access_away_cavalry, access_away_cavalry_ops)
 
 /obj/item/card/id/awaycavalry/ops/captain
 	desc = "An identification card issued to SolGov crewmembers aboard the Sol Patrol Craft."
 	icon_state = "base"
-	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_captain)
+	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_fleet_armory, access_away_cavalry_captain)
+	extra_details = list("goldstripe")
 
 /obj/item/card/id/awaycavalry/fleet
 	desc = "An identification card issued to SolGov crewmembers aboard the Sol Patrol Craft."
 	icon_state = "base"
+	color = COLOR_GRAY40
+	detail_color = "#447ab1"
 	access = list(access_away_cavalry)
+
+/obj/item/card/id/awaycavalry/fleet/pilot
+	access = list(access_away_cavalry, access_away_cavalry_pilot, access_away_cavalry_fleet_armory)
 
 /obj/item/card/id/awaycavalry/fleet/commander
 	desc = "An identification card issued to SolGov crewmembers aboard the Sol Patrol Craft."
 	icon_state = "base"
-	access = list(access_away_cavalry, access_away_cavalry_commander)
+	access = list(access_away_cavalry, access_away_cavalry_ops, access_away_cavalry_pilot, access_away_cavalry_fleet_armory, access_away_cavalry_commander) //TODO: беды с доступами
+	extra_details = list("goldstripe")
 
 /* RADIOHEADS
  * ========

--- a/maps/away_inf/sentinel/sentinel_structures.dm
+++ b/maps/away_inf/sentinel/sentinel_structures.dm
@@ -10,7 +10,6 @@
 	return list(
 		/obj/item/gun/energy/ionrifle/small  = 1,
 		/obj/item/gun/energy/plasmastun = 1,
-		/obj/item/gun/energy/laser = 3,
 		/obj/item/gun/energy/sniperrifle = 1
 	)
 


### PR DESCRIPTION
[Предложка](https://discord.com/channels/617003227182792704/755125334097133628/1076050898410815489)
ОФД для солшипа улучшено и переименовано в импульсную пушку.
Теперь консоль требует две значения для калибровки
Охлаждение импульсной пушки понижено до 30 секунд
Добавлены новые типа снарядов для импульсной пушки:
Фугасный - переработана система дамага, мощность взрыва зависит от наличия у цели работающего щита с режимом защиты от кинетики
ЭМИ - снаряд улучшен, но действует в два раза менее эффективнее, если у цели имеется работающий щит с режимом защиты от ионных штормов
Напалм - переработанный зажигательный снаряд ОФД, который распыляет и поджигает напалм(https://youtu.be/N7qkQewyubs). Не сработает, если у цели имеется работающий щит 
Маппинг и мапфиксы были сделаны @Neonvolt  


![image](https://user-images.githubusercontent.com/65360018/219971317-bcaca945-01a0-4d4e-9301-29e782cddc37.png)


🆑
tweak: improved OFD for solship and renamed to impulse cannon
tweak: added new shell types for military impulse cannon
maptweak: replaced mass driver with OFD & replaced missile-related objects with OFD charges
maptweak: remapped Ammunition Storage
maptweak: minor map fixes
tweak: Army Leader and Pilot can access Emergency armory
tweak: G40E moved from Army armory to Emergency
tweak: Pilot can unbolt cannon
maptweak: added gas storage floor decals for gas type recognition
maptweak: remapped Sentinel bridge
/🆑