### PR TITLE
Uplink без кода для наёмников

### DIFF
--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -71,7 +71,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 
 // [INF] This is our merc equipment on spawn ~ SidVeld
 	if(player.mind == leader)
-		var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, TEAM_TELECRYSTAL_AMOUNT)
+		var/obj/item/device/radio/uplink/nuclear/U = new(get_turf(player), player.mind, TEAM_TELECRYSTAL_AMOUNT)
 		player.put_in_hands(U)
 		var/obj/item/clothing/head/beret/leader = new(get_turf(player))
 		player.equip_to_slot_or_del(leader, slot_head)
@@ -80,7 +80,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 		var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in SSmachines.machinery
 		player.StoreMemory("<b>Код для активации устройства самоуничтожения [GLOB.using_map.full_name]:</b> [nuke.r_code]", /decl/memory_options/system)
 	else
-		var/obj/item/device/radio/uplink/U = new(get_turf(player), player.mind, 0)
+		var/obj/item/device/radio/uplink/nuclear/U = new(get_turf(player), player.mind, 0)
 		player.put_in_hands(U)
 		var/obj/item/paper/roles_nuclear/paper = new(get_turf(player))
 		player.put_in_hands(paper)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -291,14 +291,16 @@
 /obj/item/device/uplink/contained/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/uistate = GLOB.contained_state)
 	return ..()
 
+/obj/item/device/radio/uplink/nuclear/attack_self(mob/user as mob)
+	if(hidden_uplink)
+		hidden_uplink.trigger(user)
+
 /obj/item/device/radio/uplink/nuclear/pickup(mob/user)
 	..()
-	var/firstuser
-	if(!firstuser)
-		for(var/obj/item/device/uplink/U in contents)
+	for(var/obj/item/device/uplink/U in contents)
+		if(!U.uplink_owner)
 			U.uplink_owner = user
 			U.uses = TEAM_TELECRYSTAL_AMOUNT
-		firstuser = 1
 
 /obj/item/device/radio/uplink/empty/pickup(mob/user)
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -59,6 +59,7 @@
 	new /obj/item/modular_computer/pda/syndicate(src)
 	var/obj/item/device/radio/uplink/U = new(src)
 	U.hidden_uplink.uses = 40
+	U.desc += " A sticker is glued on the back with the inscription \"Code: " + U.access_code + "\"."
 	return
 
 /obj/structure/closet/syndicate/resources/


### PR DESCRIPTION
# Исправляет баг, из-за которого мерки не могли пользоваться аплинками из-за новой системы логина. Теперь у мерков будет новый аплинк, наследующийся от обычного, но работающий как старый без необходимости вводить код.

## Основные изменения

* У мерков вместо **/obj/item/device/radio/uplink** будет **/obj/item/device/radio/uplink/nuclear**
* **/obj/item/device/radio/uplink/nuclear** при использовании игнорирует проверку кода и автоматически открывается.
* **/obj/item/device/radio/uplink** спавнищийся в ящиках Синдиката и содержащий в себе 40 телекристаллов теперь будет иметь в описании свой код, при помощи которого им можно будет воспользоваться. 


## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
bugfix: Мерки могут пользоваться своими аплинками
/:cl:
