### PR TITLE
Mapfix: Sentinel and Farfleet minor map fixes

### DIFF
--- a/maps/away_inf/farfleet/farfleet-2.dmm
+++ b/maps/away_inf/farfleet/farfleet-2.dmm
@@ -1396,7 +1396,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse/starboard)
 "dg" = (
 /obj/machinery/pointdefense_control{
@@ -2207,7 +2207,7 @@
 	id_tag = "mws-iccg";
 	name = "Missile Warehouse"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse)
 "eO" = (
 /obj/machinery/power/terminal{
@@ -2704,7 +2704,7 @@
 	id_tag = "mwn-iccg";
 	name = "Missile Warehouse"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse/starboard)
 "gl" = (
 /obj/structure/table/steel,
@@ -3481,7 +3481,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse)
 "ll" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3809,7 +3809,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse)
 "pw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4374,7 +4374,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse)
 "uP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -5406,7 +5406,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse/starboard)
 "Eo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7396,7 +7396,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/farfleet/crew/warehouse/starboard)
 "XG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -8666,6 +8666,11 @@
 "wO" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/structure/ship_munition/disperser_charge/fire/military,
+/obj/structure/sign/warning/nosmoking_1{
+	dir = 4;
+	pixel_x = -34;
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/patrol/command/cannon)
 "xr" = (
@@ -9499,11 +9504,6 @@
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/engineering/fussion/control)
 "Vf" = (
-/obj/structure/sign/warning/nosmoking_1{
-	dir = 4;
-	pixel_x = -34;
-	pixel_y = 1
-	},
 /obj/machinery/light{
 	dir = 8
 	},

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -49,11 +49,11 @@
 	dir = 9;
 	icon_state = "warning"
 	},
+/obj/structure/catwalk,
 /obj/item/device/radio/intercom{
 	dir = 4;
-	pixel_x = -35
+	pixel_x = -22
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/ship/patrol/dock)
 "an" = (
@@ -1674,19 +1674,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/dock)
@@ -4716,7 +4715,7 @@
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/lower)
@@ -9459,6 +9458,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/ship/patrol/maintenance/engine/starboard)
+"SG" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/ship/patrol/dock)
 "SM" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -17659,7 +17667,7 @@ au
 aQ
 bn
 bS
-cB
+SG
 cB
 wN
 ex

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -2759,7 +2759,6 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/folder/blue,
-/obj/item/folder/blue,
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
@@ -8453,9 +8452,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/conveyor_switch{
 	id = "bsap";
-	name = "missile loader switch";
-	pixel_y = 8;
-	pixel_x = 10
+	name = "loading conveyor switch"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -9785,6 +9782,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
+"Zv" = (
+/obj/effect/paint/dark_gunmetal,
+/obj/machinery/conveyor_switch{
+	id = "bsap";
+	name = "loading conveyor switch"
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/patrol/command/cannon)
 "ZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -15237,7 +15242,7 @@ eb
 Ct
 MF
 Hl
-hM
+Zv
 hT
 hM
 jl

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1040,10 +1040,6 @@
 	pixel_y = 24;
 	req_access = list("access_away_cavalry")
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1056,6 +1052,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning/half,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "co" = (
@@ -1476,12 +1473,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
@@ -1680,12 +1673,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
@@ -2568,12 +2557,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
@@ -3702,9 +3687,6 @@
 /obj/item/reagent_containers/food/snacks/can,
 /obj/item/material/canknife,
 /obj/item/material/canknife,
-/obj/machinery/vending/fitness{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
 "gU" = (
@@ -4276,10 +4258,6 @@
 	pixel_y = 23;
 	req_access = list("ACCESS_CAVALRY")
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -4296,6 +4274,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning/half,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "mv" = (
@@ -4524,15 +4503,11 @@
 /area/ship/patrol/maintenance/upper/aft)
 "st" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
@@ -4577,12 +4552,8 @@
 /area/ship/patrol/maintenance/upper/starboard)
 "tE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
+/obj/effect/floor_decal/industrial/warning/half{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
@@ -4926,10 +4897,6 @@
 /turf/simulated/floor/plating,
 /area/ship/patrol/maintenance/upper/port)
 "CA" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4942,6 +4909,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning/half,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/patrol/maintenance/upper/munition)
 "CW" = (

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -1886,6 +1886,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/random/trash,
 /turf/simulated/floor,
 /area/ship/patrol/maintenance/upper)
 "dL" = (
@@ -2403,7 +2404,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/patrol/crew/brig/emergency_armory)
 "eD" = (
-/obj/random/trash,
+/obj/item/mop,
 /turf/simulated/floor,
 /area/ship/patrol/maintenance/upper)
 "eE" = (
@@ -4304,6 +4305,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/patrol/crew/hallway/upper)
+"nd" = (
+/obj/structure/janitorialcart,
+/turf/simulated/floor,
+/area/ship/patrol/maintenance/upper)
 "np" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -12252,7 +12257,7 @@ bv
 bv
 bv
 bd
-aC
+nd
 ei
 eF
 eX

--- a/maps/away_inf/sentinel/sentinel-2.dmm
+++ b/maps/away_inf/sentinel/sentinel-2.dmm
@@ -3417,11 +3417,17 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
 "gq" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
 "gr" = (
 /obj/machinery/gibber,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
 "gt" = (
@@ -3698,9 +3704,6 @@
 "gV" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24;
@@ -3809,10 +3812,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)
 "hg" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3834,6 +3833,9 @@
 	dir = 1;
 	pixel_y = -24;
 	req_access = list("ACCESS_CAVALRY")
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/patrol/crew/kitchen)

--- a/maps/away_inf/sentinel/sentinel_turbolift.dm
+++ b/maps/away_inf/sentinel/sentinel_turbolift.dm
@@ -32,5 +32,5 @@
 	name = "lift (lower deck)"
 	lift_floor_label = "Deck 2"
 	lift_floor_name = "Utility Deck"
-	lift_announce_str = "Arriving at Utility Deck: Мостик. Ангар. Атмосферный отсек. Реактор R-UST. Личное снаряжение. Отсек EVA. Секция Пехоты. Ракетный отсек. Медбей."
+	lift_announce_str = "Arriving at Utility Deck: Мостик. Ангар. Атмосферный отсек. Реактор R-UST. Личное снаряжение. Отсек EVA. Секция Пехоты. Импульсное орудие. Медбей."
 	base_turf = /turf/simulated/floor


### PR DESCRIPTION
# Описание

Случайно поставил вендомат куда не надо, когда маппил свой прошлый ПР. К сожалению упустил его и не заметил раньше.
Также добавил тележку уборщика и швабру к ней в техи. Их просто не хватало. И починил некоторые турфы на ГКК, по запросу.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Neonvolt
bugfix: removed vendomat from Sentinel kitchen, where it doesn't belong
bugfix: replaced unexpected airless floor turfs on Farfleet
maptweak: added jani cart and mops on Sentinel
/:cl:
