### PR TITLE
minig statian back to overmap

### DIFF
--- a/maps/away_inf/miningstation/miningstation.dmm
+++ b/maps/away_inf/miningstation/miningstation.dmm
@@ -7394,6 +7394,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/miningstation/bathroom)
+"qr" = (
+/obj/effect/shuttle_landmark/nav_miningstation/exterior,
+/turf/space,
+/area/space)
 "qs" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/trauma,
@@ -8001,7 +8005,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/miningstation/prep2)
 "Iv" = (
-/obj/effect/shuttle_landmark/automatic,
+/obj/effect/shuttle_landmark/nav_miningstation/hangar,
 /turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "ID" = (
@@ -8126,6 +8130,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/miningstation/cryo)
+"QB" = (
+/obj/effect/overmap/visitable/sector/miningstation,
+/turf/space,
+/area/space)
 "Rh" = (
 /mob/living/simple_animal/hostile/meat/horrorminer,
 /turf/simulated/floor/tiled/techfloor,
@@ -18185,9 +18193,9 @@ aw
 aw
 aw
 aw
+aw
+aw
 Iv
-aw
-aw
 aw
 aw
 aw
@@ -19738,7 +19746,7 @@ hv
 hw
 aa
 aa
-aa
+QB
 aa
 aa
 aa
@@ -25768,7 +25776,7 @@ aa
 aa
 aa
 aa
-aa
+qr
 aa
 aa
 aa


### PR DESCRIPTION
Вернул шахтерскую станцию из ада на овермапу. Поправил посадочные места.

## Скриншоты
![image](https://user-images.githubusercontent.com/95378033/221052357-e0b02fdb-0ff2-48c6-b410-3c88681d19f0.png)
![image](https://user-images.githubusercontent.com/95378033/221052388-d47ebba1-5d2c-4dd4-a9d4-d690ce3f6d2b.png)


## Changelog

:cl:
bugfix:  sector/miningstation back to over map
/:cl:
