### PR TITLE
Maptweak: additional navpoints for Mining Station, Sentinel map tweaks

### DIFF
--- a/maps/away/miningstation/miningstation.dm
+++ b/maps/away/miningstation/miningstation.dm
@@ -5,15 +5,17 @@
 	name = "Orbital Mining Station"
 	scanner_name = "Orbital Mining Station"
 	scanner_name = "Asteroid Mining Station"
-	scanner_desc = @{"[i]Registration[/i]: Grayson Mining Industries
-[i]Class[/i]: Installation
-[i]Transponder[/i]: None Detected
-[b]Notice[/b]: An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station. It is emitting a weak signal on a public frequency, with no other discernible radio traffic."}
+	scanner_desc = @{"<i>Registration</i>: Grayson Mining Industries<br>
+<i>Class</i>: Installation<br>
+<i>Transponder</i>: None Detected<br>
+<b>Notice</b>: An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station. It is emitting a weak signal on a public frequency, with no other discernible radio traffic."}
 	icon_state = "object"
 	known = 0
 	initial_generic_waypoints = list(
-		"nav_miningstation_hangar",
-		"nav_miningstation_exterior",
+		"nav_miningstation_hangar1",
+		"nav_miningstation_hangar2",
+		"nav_miningstation_exterior1",
+		"nav_miningstation_exterior2",
 	)
 
 /datum/map_template/ruin/away_site/miningstation
@@ -25,15 +27,25 @@
 	spawn_cost = 1
 	area_usage_test_exempted_root_areas = list(/area/miningstation)
 
-/obj/effect/shuttle_landmark/nav_miningstation/hangar
-	name = "Hangar"
-	landmark_tag = "nav_miningstation_hangar"
+/obj/effect/shuttle_landmark/nav_miningstation/hangar1
+	name = "Hangar Landing Zone A"
+	landmark_tag = "nav_miningstation_hangar1"
 	base_area = /area/miningstation/hangar
 	base_turf = /turf/simulated/floor/plating
 
-/obj/effect/shuttle_landmark/nav_miningstation/exterior
-	name = "Near the orbital station"
-	landmark_tag = "nav_miningstation_exterior"
+/obj/effect/shuttle_landmark/nav_miningstation/hangar2
+	name = "Hangar Landing Zone B"
+	landmark_tag = "nav_miningstation_hangar2"
+	base_area = /area/miningstation/hangar
+	base_turf = /turf/simulated/floor/plating
+
+/obj/effect/shuttle_landmark/nav_miningstation/exterior1
+	name = "North-East of the orbital station"
+	landmark_tag = "nav_miningstation_exterior1"
+
+/obj/effect/shuttle_landmark/nav_miningstation/exterior2
+	name = "South-West of the orbital station"
+	landmark_tag = "nav_miningstation_exterior2"
 
 
 ///////////////////////////////////crew

--- a/maps/away_inf/miningstation/miningstation.dmm
+++ b/maps/away_inf/miningstation/miningstation.dmm
@@ -7395,7 +7395,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/miningstation/bathroom)
 "qr" = (
-/obj/effect/shuttle_landmark/nav_miningstation/exterior,
+/obj/effect/shuttle_landmark/nav_miningstation/exterior2,
 /turf/space,
 /area/space)
 "qs" = (
@@ -8005,7 +8005,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/miningstation/prep2)
 "Iv" = (
-/obj/effect/shuttle_landmark/nav_miningstation/hangar,
+/obj/effect/shuttle_landmark/nav_miningstation/hangar2,
 /turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "ID" = (
@@ -8082,6 +8082,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/miningstation/operationshall)
+"NN" = (
+/obj/effect/shuttle_landmark/nav_miningstation/hangar1,
+/turf/simulated/floor/plating,
+/area/miningstation/hangar)
 "Oa" = (
 /obj/machinery/cryopod{
 	dir = 2
@@ -8130,6 +8134,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/miningstation/cryo)
+"Qi" = (
+/obj/effect/shuttle_landmark/nav_miningstation/exterior1,
+/turf/space,
+/area/space)
 "QB" = (
 /obj/effect/overmap/visitable/sector/miningstation,
 /turf/space,
@@ -11879,7 +11887,7 @@ aa
 aa
 aa
 aa
-aa
+qr
 aa
 aa
 aa
@@ -17586,7 +17594,7 @@ aw
 aw
 aw
 aw
-aw
+NN
 aw
 aw
 aw
@@ -18195,7 +18203,7 @@ aw
 aw
 aw
 aw
-Iv
+aw
 aw
 aw
 aw
@@ -19415,7 +19423,7 @@ aw
 aw
 aw
 aw
-aw
+Iv
 aw
 aw
 aw
@@ -25627,7 +25635,7 @@ aa
 aa
 aa
 aa
-aa
+Qi
 aa
 aa
 aa
@@ -25776,7 +25784,7 @@ aa
 aa
 aa
 aa
-qr
+aa
 aa
 aa
 aa

--- a/maps/away_inf/sentinel/sentinel-1.dmm
+++ b/maps/away_inf/sentinel/sentinel-1.dmm
@@ -4691,10 +4691,10 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/ship/patrol/medbay)
 "iJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/dark_gunmetal,
-/turf/simulated/floor,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/ship/patrol/medbay)
 "iK" = (
 /obj/effect/paint/dark_gunmetal,
@@ -5013,14 +5013,15 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/latex,
+/obj/item/storage/box/beakers,
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jr" = (
-/obj/structure/table/rack,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/item/storage/box/beakers,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/gloves/latex,
+/obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "js" = (
@@ -5324,16 +5325,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/bed/chair/office/comfy/blue{
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jW" = (
@@ -5342,7 +5340,13 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/obj/machinery/chemical_dispenser/full,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/bed/chair/office/comfy/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "jX" = (
@@ -5548,21 +5552,21 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kr" = (
-/obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/smartfridge/secure/medbay{
+	dir = 1;
+	req_access = list("ACCESS_CAVALRY")
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "ks" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/chem_master,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "kt" = (
@@ -5801,18 +5805,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/ship/patrol/medbay)
+"kR" = (
 /obj/effect/floor_decal/corner/pink{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/patrol/medbay)
-"kR" = (
-/obj/structure/table/rack,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/effect/floor_decal/corner/pink/mono,
-/turf/simulated/floor/tiled/white/monotile,
 /area/ship/patrol/medbay)
 "kS" = (
 /obj/structure/table/rack,
@@ -6122,8 +6121,15 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "lu" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/corner/pink/mono,
+/obj/structure/table/rack,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
 /turf/simulated/floor/tiled/white/monotile,
 /area/ship/patrol/medbay)
 "lv" = (
@@ -6344,10 +6350,7 @@
 	dir = 9;
 	icon_state = "warning"
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/vending/medical/advanced{
 	dir = 8;
 	req_access = list("ACCESS_CAVALRY")
@@ -6581,14 +6584,11 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "mo" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/smartfridge/secure/medbay{
-	dir = 8;
-	req_access = list("ACCESS_CAVALRY")
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/white,
 /area/ship/patrol/medbay)
 "mp" = (
@@ -9782,14 +9782,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/ship/patrol/command/bridge)
-"Zv" = (
-/obj/effect/paint/dark_gunmetal,
-/obj/machinery/conveyor_switch{
-	id = "bsap";
-	name = "loading conveyor switch"
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/patrol/command/cannon)
 "ZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -15242,7 +15234,7 @@ eb
 Ct
 MF
 Hl
-Zv
+hM
 hT
 hM
 jl
@@ -15736,8 +15728,8 @@ iI
 kq
 jU
 kq
-kQ
 ls
+kQ
 lN
 mm
 mQ
@@ -15858,8 +15850,8 @@ iJ
 jq
 jV
 kr
-kR
 lt
+kR
 lO
 mn
 mP

--- a/maps/away_inf/sentinel/sentinel.dm
+++ b/maps/away_inf/sentinel/sentinel.dm
@@ -15,8 +15,8 @@
 	scanner_name = "Multipurpose Patrol Craft"
 	scanner_desc = @{"
 		<center><img src = FleetLogo.png><br>
-		<i>Registration</i>: SCGDF Multipurpose Patrol Craft
-		<i>Transponder</i>: Transmitting (MIL), SCG
+		<i>Registration</i>: SCGDF Multipurpose Patrol Craft<br>
+		<i>Transponder</i>: Transmitting (MIL), SCG<br>
 		<b>Notice</b>: Nagashino-class Multipurpose Patrol Craft. Fine example of human fleet brilliant technologies with 5th Fleet designation and massive heat footprint."}
 	contact_class = /decl/ship_contact_class/nagashino
 	color = "#990000"

--- a/maps/away_inf/sentinel/sentinel_shuttle.dm
+++ b/maps/away_inf/sentinel/sentinel_shuttle.dm
@@ -19,9 +19,9 @@
 	scanner_name = "Reaper-G"
 	scanner_desc = @{"
 		<center><img src = FleetLogo.png><br>
-		<i>Registration</i>: SCGDF Shuttle
-		<i>Class[/i]: Shuttle
-		<i>Transponder</i>: Transmitting (MIL), SCG
+		<i>Registration</i>: SCGDF Shuttle<br>
+		<i>Class</i>: Shuttle<br>
+		<i>Transponder</i>: Transmitting (MIL), SCG<br>
 		<b>Notice</b>: A heavily modified military gunboat of particular design. More of the dropship now, scanner detects heavy alteration to the hull of the vessel and no designation"}
 	shuttle = "Reaper Gunboat"
 	fore_dir = WEST

--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -27977,9 +27977,6 @@
 "SF" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small,
-/obj/item/music_tape/custom{
-	randpixel = 0
-	},
 /obj/item/paper/travelvisa{
 	desc = "A flimsy piece of laminated cardboard issued by the Sol Central Government. It's look's damaged"
 	},


### PR DESCRIPTION
# Описание

Вообщем, я опять накосячил при маппинге и не увидел баг на патрульке, так что убираю сейчас. И еще изменил там уголок химика, чтобы было удобней работать: холодильник для лекарств теперь в прямой досягаемости, не надо бегать до него каждый раз. 
Бонусом решил добавить дополнительные точки для шаттлов на шахтерскую станцию из #507. Теперь есть 2 внешние точки для подлета (северо-восток и юго-запад), а также 2 внутренние, в ангаре. В нем я метки ставил специально так, чтобы помещались и ГУП и Харон одновременно.

## Основные изменения

* Слегка переставлены объекты в меде патрульки, убран случайный рычаг
* Дополнительные точки для посадки/подлета для шахтерской станции

## Скриншоты

![image](https://user-images.githubusercontent.com/83385197/221275710-0dd77f92-c424-49f4-9199-d6a0f690d37f.png)

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Neonvolt
bugfix: removed random mapped leveler from Sentinel
bugfix: fixed scan data for Sentinel. Reaper-G, and Mining Station
maptweak: small map changes in Sentinel medbay
rscdel: removed dusty tape from Third Deck - Abandoned - Requisition
rscadd: Mining Station gets additional shuttle landmarks
/:cl:
