### PR TITLE
Tweak: adds psi-null implant to consouler clothet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -162,7 +162,8 @@
 		/obj/item/device/tape/random = 3,
 		/obj/item/device/camera,
 		/obj/item/toy/therapy_blue,
-		/obj/item/storage/belt/general
+		/obj/item/storage/belt/general,
+		/obj/item/implanter/psi = 5
 	)
 
 /obj/structure/closet/secure_closet/virology


### PR DESCRIPTION
Дополнение к прошедшей предложке на псионику, забыл совсем про то что там еще надо было добавить импланты подавления