### PR TITLE
Mapfix: removed emergency closet from airlock

### DIFF
--- a/maps/sierra/sierra-1.dmm
+++ b/maps/sierra/sierra-1.dmm
@@ -833,10 +833,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/closet/emcloset{
-	anchored = 1;
-	name = "anchored emergency closet"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/thirddeck/fore)
 "bR" = (
@@ -19893,17 +19889,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckofficer)
-"Fu" = (
-/obj/structure/closet/emcloset{
-	anchored = 1;
-	name = "anchored emergency closet"
-	},
-/obj/effect/floor_decal/corner/lightgrey/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj,
-/obj,
-/turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
 "Fv" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -44675,7 +44660,7 @@ Is
 Is
 Is
 fB
-Fu
+kp
 KJ
 Lu
 uM


### PR DESCRIPTION
# Описание

Как-то раньше этого не замечали. Или предпочитали игнорировать. Но теперь шкафа, который ни одно живое существо не способно сдвинуть, в шлюзе больше нет.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: 
bugfix: removed anchored O2 closet from external airlock on D3
bugfix: removed invalid empty objects
/:cl:
