### PR TITLE
bugfix: yeosa and vox loadout fix

### DIFF
--- a/maps/sierra/loadout/loadout_xeno.dm
+++ b/maps/sierra/loadout/loadout_xeno.dm
@@ -5,7 +5,7 @@
 	path = /obj/item/passport/xeno/unathi
 	sort_category = "Xenowear"
 	flags = 0
-	whitelisted = list(SPECIES_UNATHI)
+	whitelisted = list(SPECIES_UNATHI, SPECIES_YEOSA)
 	custom_setup_proc = /obj/item/passport/proc/set_info
 	cost = 0
 
@@ -83,13 +83,13 @@
 // Vox clothing
 
 /datum/gear/mask/gas/vox
-	allowed_roles = list(/datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /*/datum/job/stowaway*/)
+	whitelisted = list(SPECIES_VOX)
 
 /datum/gear/gloves/vox
-	allowed_roles = list(/datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /*/datum/job/stowaway*/)
+	whitelisted = list(SPECIES_VOX)
 
 /datum/gear/uniform/vox_cloth
-	allowed_roles = list(/datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /*/datum/job/stowaway*/)
+	whitelisted = list(SPECIES_VOX)
 
 /datum/gear/uniform/vox_robe
-	allowed_roles = list(/datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /*/datum/job/stowaway*/)
+	whitelisted = list(SPECIES_VOX)


### PR DESCRIPTION
Фикс невозможности воксам брать воксовещи в лодауте и невозможности Йоза'Унатам брать регистрационный документ.

# Описание

Фикс невозможности воксам брать воксовещи в лодауте и невозможности Йоза'Унатам брать регистрационный документ.


## Основные изменения

* Йоза могут брать ящерский паспорт
* Воксы могут брать воксовские вещи.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
bugfix: Исправил невозможность для воксам брать вещи воксов и невозможность для Йоза'Унатов брать регистрационный паспорт.
/:cl:
