### PR TITLE
Витрина в каюте кэпа перестанет пустовать.

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -67,3 +67,9 @@
 	desc = "A polished cutlass issued to chief petty officers of the fleet."
 	icon_state = "pettyofficersword"
 	item_state = "pettyofficersword"
+
+/obj/item/material/sword/replica/officersword/executor
+	name = "executor"
+	desc = "Sharpened, first-class captain's saber with \"Executor\" engraved on the blade. \"If the argument doesn't work, then it steps in.\""
+	icon_state = "armyofficersword"
+	item_state = "armyofficersword"

--- a/maps/sierra/sierra-2.dmm
+++ b/maps/sierra/sierra-2.dmm
@@ -3616,15 +3616,15 @@
 	},
 /obj/structure/table/standard,
 /obj/item/towel/random{
-	pixel_y = -4;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/item/storage/box/detergent{
-	pixel_y = 4;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/captain/beach)
@@ -3828,11 +3828,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor/westleft{
+	dir = 2;
 	id_tag = null;
 	polarized = 1;
 	req_access = list("ACCESS_CAPTAIN");
-	tint_id = "cap_room_window";
-	dir = 2
+	tint_id = "cap_room_window"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
@@ -6407,12 +6407,12 @@
 	},
 /obj/structure/table/woodentable/walnut,
 /obj/item/device/flashlight/lamp/green{
-	pixel_y = 8;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 8
 	},
 /obj/item/toy/figure/captain{
-	pixel_y = 2;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 2
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
@@ -8088,13 +8088,13 @@
 	req_access = list("ACCESS_CAPTAIN")
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 24
 	},
 /obj/machinery/button/windowtint{
-	pixel_y = 24;
+	id = "cap_windows";
 	pixel_x = -3;
-	id = "cap_windows"
+	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/captain/office_anteroom)
@@ -9565,6 +9565,9 @@
 	name = "heavy display case";
 	req_access = list("ACCESS_CAPTAIN")
 	},
+/obj/item/material/sword/replica/officersword/executor{
+	pixel_y = -4
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/cobed)
 "ari" = (
@@ -10226,8 +10229,8 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/hand_labeler,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	dir = 4
+	dir = 4;
+	pixel_x = -24
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -12285,8 +12288,8 @@
 /area/engineering/engine_room)
 "avP" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/random/date_based/christmas/xmaslights,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -14346,8 +14349,8 @@
 /area/hallway/primary/seconddeck/central_stairwell)
 "azh" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	dir = 4
+	dir = 4;
+	pixel_x = -24
 	},
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -14421,8 +14424,8 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	pixel_y = 0;
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
@@ -14844,8 +14847,8 @@
 /area/engineering/locker_room)
 "azS" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/structure/holoplant,
 /turf/simulated/floor/tiled/dark,
@@ -17175,10 +17178,10 @@
 /obj/item/pen,
 /obj/item/folder/nt,
 /obj/machinery/button/windowtint{
-	pixel_x = -23;
-	pixel_y = 3;
+	dir = 4;
 	id = "bridge_windows";
-	dir = 4
+	pixel_x = -23;
+	pixel_y = 3
 	},
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 8
@@ -17258,8 +17261,8 @@
 /obj/machinery/button/blast_door{
 	id_tag = "heads_meeting";
 	name = "Conference Room Shutters Control";
-	pixel_y = 28;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 28
 	},
 /obj/machinery/button/windowtint{
 	id = "meeting_windows";
@@ -20149,8 +20152,8 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/central_stairwell)
@@ -21384,8 +21387,8 @@
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/structure/holoplant,
 /obj/effect/floor_decal/corner/lime/border{
@@ -23989,8 +23992,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -24;
-	dir = 4
+	dir = 4;
+	pixel_x = -24
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/industrial/danger,
@@ -28602,8 +28605,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -29279,8 +29282,8 @@
 "baf" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -21;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -21
 	},
 /obj/structure/holoplant,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -29292,12 +29295,12 @@
 	dir = 9
 	},
 /obj/machinery/button/blast_door{
+	dir = 1;
 	id_tag = "infirmaryquar";
 	name = "Infirmary Quar Lockdown";
 	pixel_x = 6;
 	pixel_y = -21;
-	req_access = list("ACCESS_MEDICAL");
-	dir = 1
+	req_access = list("ACCESS_MEDICAL")
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/maintenance_equipstorage)
@@ -29747,8 +29750,8 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 24;
-	dir = 8
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/sauna)
@@ -30535,8 +30538,8 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	pixel_y = 0;
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/machinery/disposal/small,
 /obj/effect/floor_decal/spline/fancy/black{
@@ -31015,8 +31018,8 @@
 /obj/item/device/flashlight/lantern,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/chapel/office)
@@ -31462,8 +31465,8 @@
 	dir = 1;
 	id_tag = "chapel";
 	name = "Last Way";
-	pixel_y = -20;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -20
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -34028,8 +34031,8 @@
 	pixel_x = 24
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -22;
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/random/date_based/christmas/xmaslights,
 /obj/machinery/light,
@@ -35585,8 +35588,8 @@
 	dir = 8
 	},
 /obj/item/taperoll/bog{
-	pixel_y = 11;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 11
 	},
 /obj/item/device/radio/intercom/locked/ai_private{
 	dir = 1;
@@ -39109,8 +39112,8 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	dir = 8
+	dir = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39134,8 +39137,8 @@
 /obj/effect/floor_decal/spline/fancy/black/corner,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head_big)
@@ -39315,8 +39318,8 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -39683,8 +39686,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/civilian{
-	name = "Kitchen";
-	dir = 4
+	dir = 4;
+	name = "Kitchen"
 	},
 /obj/machinery/door/firedoor,
 /obj/random/date_based/christmas/doorwreath{
@@ -39923,9 +39926,9 @@
 	pixel_y = 32
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 29;
 	dir = 2;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 29
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/center)
@@ -40893,8 +40896,8 @@
 /obj/structure/flora/pottedplant/tropical,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/crew_quarters/lounge_big)
@@ -41700,8 +41703,8 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/bar_fruit_jar{
-	pixel_y = 16;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 16
 	},
 /turf/simulated/floor/wood/ebony,
 /area/crew_quarters/bar)


### PR DESCRIPTION
У нас есть аргумент, но нет экзекутора в случае отказа и этот ПР добавит его! Встречайте... Executor- сабля, что будет лежать в ранее пустой витрине, в каюте капитана наконец-то она не будет пустой, а капитан обзаведётся саблей которая есть у него в каждом билде? Но это не суть ПРа, главной сутью является заполнение пустующей витрины.

Изменения:
1. Добавлена сабля в витрину в каюте кэпа.
2. Добавлен предмет, который является копией army officer's sword, но имеет другой desc и name, возможно когда-то это будет отдельный предмет...