### PR TITLE
Feat: add temperature stat for Machines 

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(compatable_genomes_owners)
 		var/obj/item/organ/internal/cell/potato = internal_organs_by_name[BP_CELL]
 		if(potato && potato.cell)
 			stat("Battery charge:", "[potato.get_charge()]/[potato.cell.maxcharge]")
-
+			stat("Operating temperature:", "[round(bodytemperature-T0C)]&deg;C")
 		if(back && istype(back,/obj/item/rig))
 			var/obj/item/rig/suit = back
 			var/cell_status = "ERROR"


### PR DESCRIPTION
# Описание

Смотрим ниже

## Основные изменения

Добавляет в статус панели строчку Operating temperature показывающую температуру тела машинки

![image](https://github.com/ss220-space/Baystation12/assets/61974560/11c92c6a-4576-4413-affd-c5df7b48160f)


:cl:
tweak: Добавляет в статус панели строчку Operating temperature показывающую температуру тела машинки
/:cl:
