### PR TITLE
Fix: spacesuit helmet visibility

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -61,6 +61,7 @@
 	name = "spacesuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. The tinting can be toggled for flash protection at the cost of worse visibility."
 	icon_state = "spacebowl"
+	item_state = "spacebowl"
 	light_overlay = "yellow_light"
 	tinted = FALSE
 	tint = 0 //INF, WAS NOTHING (0)


### PR DESCRIPTION
# Описание

Исправлена ошибка, из-за которой при тонировке стекла на шлеме шлем исчезал

## Основные изменения

добавлена строка item_state = "spacebowl"

## Скриншоты

| Было                   | Стало                  |
| ---------------------- | ---------------------- |
| ![image](https://github.com/ss220-space/Baystation12/assets/113102687/34453822-5945-4e7b-940d-88e5547a3b8a) | ![image](https://github.com/ss220-space/Baystation12/assets/113102687/3899dbf4-ca89-48d4-acae-76dfdc07b529) |

## Changelog

:cl:
bugfix: исправлена тонировка стекла на шлеме
/:cl:
