### PR TITLE
GAS - C+ can no longer be Research Assistant

### DIFF
--- a/maps/sierra/job/jobs.dm
+++ b/maps/sierra/job/jobs.dm
@@ -86,8 +86,7 @@
 
 
 /decl/cultural_info/culture/nabber/c/plus
-	valid_jobs = list(/datum/job/janitor,    /datum/job/cargo_assistant,
-					  /datum/job/scientist_assistant)
+	valid_jobs = list(/datum/job/janitor,    /datum/job/cargo_assistant)
 
 
 // GRADE B


### PR DESCRIPTION
Серпентиды С+ класса больше не могут быть ресёрч ассистантами

:cl:
tweak: C+ GAS can no longer be Research Assistant
/:cl:
