### PR TITLE
Изменение префов

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -91,6 +91,7 @@ var/list/_client_preferences_by_type
 /datum/client_preference/play_lobby_music
 	description = "Play lobby music"
 	key = "SOUND_LOBBY"
+	default_value = GLOB.PREF_NO
 
 /datum/client_preference/play_lobby_music/changed(var/mob/preference_mob, var/new_value)
 	if(new_value == GLOB.PREF_YES)
@@ -230,6 +231,7 @@ var/list/_client_preferences_by_type
 	description = "Autohiss"
 	key = "AUTOHISS"
 	options = list(GLOB.PREF_OFF, GLOB.PREF_BASIC, GLOB.PREF_FULL)
+	default_value = GLOB.PREF_FULL
 
 /datum/client_preference/hardsuit_activation
 	description = "Hardsuit Module Activation Key"


### PR DESCRIPTION
# Описание

Изменение дефолтов глобальных префов

## Основные изменения

* Музыка лобби теперь не ебошит при каждой перезагрузке сервера
* Бедным ксено не нужно каждый раз переключать обратно автохисс из-за ошибки прогрузки персонажей и слёта глобальных префов


## Скриншоты

## Changelog

:cl:
tweak: autohiss default is full
tweak: play lobby music default is off 
/:cl:
