### PR TITLE
Add manual transfer vote cooldown

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -46,6 +46,7 @@ var/list/gamemode_cache = list()
 	var/vote_autotransfer_initial = 120 MINUTES // Length of time before the first autotransfer vote is called
 	var/vote_autotransfer_interval = 30 MINUTES // length of time before next sequential autotransfer vote
 	var/vote_manual_transfer_initial = 120 MINUTES // Length of time before the first manual transfer vote could be called
+	var/vote_manual_transfer_cooldown = 30 MINUTES // Length of time before the next manual transfer vote could be called
 	var/vote_autogamemode_timeleft = 100 //Length of time before round start when autogamemode vote is called (in seconds, default 100).
 	var/vote_no_default = 0				// vote does not default to nochange/norestart (tbi)
 	var/vote_no_dead = 0				// dead people can't vote (tbi)
@@ -439,6 +440,9 @@ var/list/gamemode_cache = list()
 
 				if ("vote_manual_transfer_initial")
 					config.vote_manual_transfer_initial = text2num(value) MINUTES
+
+				if ("vote_manual_transfer_cooldown")
+					config.vote_manual_transfer_cooldown = text2num(value) MINUTES
 
 				if ("vote_autogamemode_timeleft")
 					config.vote_autogamemode_timeleft = text2num(value)

--- a/code/datums/vote/manual_transfer.dm
+++ b/code/datums/vote/manual_transfer.dm
@@ -4,6 +4,7 @@
 /datum/vote/transfer_manual
 	name = "manual transfer"
 	question = "End the shift?"
+	var/static/last_vote = 0
 
 /datum/vote/transfer_manual/can_run(mob/creator, automatic)
 	if(!(. = ..()))
@@ -17,6 +18,9 @@
 	if(world.time < config.vote_manual_transfer_initial)
 		to_chat(creator, "Manual crew transfer could be called after [(config.vote_manual_transfer_initial - world.time) / 600] minutes!")
 		return FALSE
+	if (world.time < last_vote + config.vote_manual_transfer_cooldown)
+		to_chat(creator, "Manual crew transfer could be called after [((last_vote + config.vote_manual_transfer_cooldown) - world.time) / 600] minutes!")
+		return FALSE
 	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
 	if (!automatic && security_state.current_security_level_is_same_or_higher_than(security_state.high_security_level))
 		to_chat(creator, "The current alert status is too high to call for a crew transfer!")
@@ -27,6 +31,7 @@
 
 /datum/vote/transfer_manual/setup_vote(mob/creator, automatic)
 	choices = list(CHOICE_TRANSFER, CHOICE_EXTEND)
+	last_vote = world.time
 	..()
 
 /datum/vote/transfer_manual/handle_default_votes()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -434,3 +434,12 @@ RADIATION_LOWER_LIMIT 0.15
 ## Add lines of 'DISALLOW_VOTABLE_MODE config_tag' to prevent a normally votable mode from being votable, eg:
 ## DISALLOW_VOTABLE_MODE changeling
 ## DISALLOW_VOTABLE_MODE malfunction
+
+
+## Manual transfer vote cooldowns (in minutes)
+
+## Length of time before the first manual transfer vote could be called
+#VOTE_MANUAL_TRANSFER_INITIAL 120
+
+## Length of time before the next manual transfer vote could be called
+#VOTE_MANUAL_TRANSFER_COOLDOWN 30


### PR DESCRIPTION
Добавляет кулдаун между запросами шаттла, потому что дефолтный в 10 минут, применяемый ко всем голосованиям, слишком мелкий и здесь требуется отдельный