### PR TITLE
Avey shuttles remap

### DIFF
--- a/maps/away_inf/bearcat/bearcat-1.dmm
+++ b/maps/away_inf/bearcat/bearcat-1.dmm
@@ -2682,7 +2682,7 @@
 /turf/simulated/floor/usedup,
 /area/ship/scrap/maintenance/storage)
 "eU" = (
-/obj/machinery/vending/tool/bearcat,
+/obj/machinery/suit_cycler/engineering,
 /turf/simulated/floor/usedup,
 /area/ship/scrap/maintenance/storage)
 "eV" = (

--- a/maps/away_inf/bearcat/bearcat-2.dmm
+++ b/maps/away_inf/bearcat/bearcat-2.dmm
@@ -4282,11 +4282,11 @@
 /obj/structure/sign/warning/compressed_gas{
 	pixel_x = -32
 	},
-/obj/structure/bed/padded,
 /obj/machinery/power/apc/derelict/bearcat{
 	dir = 1;
 	name = "area power controller"
 	},
+/obj/machinery/vending/tool/bearcat,
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "hn" = (
@@ -6374,9 +6374,6 @@
 /obj/item/toy/prize/powerloader,
 /obj/item/material/ashtray/plastic,
 /obj/machinery/recharger,
-/obj/structure/sign/poster{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled/usedup,
 /area/ship/scrap/maintenance/engineering)
 "Lp" = (

--- a/maps/away_inf/liberia/liberia.dmm
+++ b/maps/away_inf/liberia/liberia.dmm
@@ -58,14 +58,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "af" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/rd,
-/obj/item/storage/secure/safe{
-	pixel_x = 34
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/submap_landmark/spawnpoint/liberia,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/wall/prepainted,
 /area/liberia/captain)
 "ag" = (
 /obj/structure/bed/padded,
@@ -115,6 +108,11 @@
 	name = "merchant's locker"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/belt/holster/ic/full,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/mask/gas/alt,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/bandana/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/liberia/merchantstorage)
 "ao" = (
@@ -736,6 +734,8 @@
 /obj/item/clothing/glasses/tacgoggles,
 /obj/item/clothing/accessory/legguards,
 /obj/item/clothing/under/syndicate,
+/obj/item/clothing/suit/armor/pcarrier,
+/obj/item/clothing/head/helmet,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/liberia/mule)
 "bt" = (
@@ -1741,11 +1741,12 @@
 /area/liberia/engineeringengines)
 "cZ" = (
 /obj/structure/table/woodentable/walnut,
-/obj/machinery/chemical_dispenser/bar_coffee{
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	pixel_y = 8;
+	dir = 1
 	},
 /turf/simulated/floor/carpet/red,
 /area/liberia/traidingroom)
@@ -2590,7 +2591,7 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
-/obj/item/instrument/guitar,
+/obj/item/device/synthesized_instrument/guitar,
 /turf/simulated/floor/tiled/steel_grid,
 /area/liberia/mule)
 "ej" = (
@@ -3282,8 +3283,7 @@
 "fr" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 1;
-	icon_state = "air_map";
-	start_pressure = 740.5
+	icon_state = "air_map"
 	},
 /obj/machinery/light/small,
 /obj/effect/floor_decal/borderfloor,
@@ -3296,8 +3296,7 @@
 "fs" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 1;
-	icon_state = "air_map";
-	start_pressure = 740.5
+	icon_state = "air_map"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -3613,12 +3612,11 @@
 /area/liberia/bar)
 "fU" = (
 /obj/structure/table/woodentable/walnut,
-/obj/random/drinkbottle,
-/obj/random/drinkbottle,
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = null
 	},
+/obj/machinery/chemical_dispenser/bar_alc,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "fV" = (
@@ -3937,6 +3935,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gy" = (
@@ -3964,6 +3963,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
 /turf/simulated/floor/wood/ebony,
 /area/liberia/bar)
 "gA" = (
@@ -4143,12 +4144,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/wood/ebony,
-/area/liberia/captain)
-"gP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/turf/simulated/floor/wood/ebony,
+/area/liberia/captain)
+"gP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4159,6 +4160,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
@@ -4201,33 +4205,29 @@
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
 "gS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/blue{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
 "gT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -4238,7 +4238,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/light,
 /obj/structure/cable/blue{
 	d1 = 1;
 	d2 = 8;
@@ -4346,12 +4345,8 @@
 /turf/simulated/floor/wood/ebony,
 /area/liberia/captain)
 "hi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/plain/brown,
-/turf/simulated/floor/wood/ebony,
+/turf/simulated/wall/prepainted,
 /area/liberia/captain)
 "hj" = (
 /obj/machinery/door/airlock{
@@ -4456,21 +4451,18 @@
 /turf/simulated/floor/carpet,
 /area/liberia/personellroom2)
 "hv" = (
+/obj/machinery/door/window/northleft{
+	name = "Kitchen"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/liberia/bar)
+"hw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/clothing/suit/chef/classic,
-/obj/item/material/kitchen/rollingpin,
-/obj/item/material/knife/kitchen,
-/turf/simulated/floor/tiled/freezer,
-/area/liberia/bar)
-"hw" = (
-/obj/machinery/door/window/northleft{
-	name = "Kitchen"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/bar)
 "hx" = (
@@ -4534,22 +4526,18 @@
 "hE" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/carpet/red,
-/area/liberia/captain)
-"hF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
 	},
+/turf/simulated/floor/carpet/red,
+/area/liberia/captain)
+"hF" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/carpet/red,
+/turf/simulated/wall/prepainted,
 /area/liberia/captain)
 "hG" = (
 /obj/structure/closet/cabinet,
@@ -4581,14 +4569,8 @@
 /turf/simulated/floor/carpet,
 /area/liberia/personellroom2)
 "hJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/machinery/alarm/merchant{
-	dir = 4;
-	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/bar)
@@ -4602,13 +4584,14 @@
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/bar)
 "hL" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/bar)
@@ -4644,13 +4627,6 @@
 /turf/simulated/floor/carpet,
 /area/liberia/personellroom2)
 "hQ" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = -21
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = newlist()
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/liberia/bar)
 "hR" = (
@@ -6801,19 +6777,31 @@
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
 "no" = (
+/obj/structure/undies_wardrobe,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/storage/secure/safe{
+	pixel_x = 34
+	},
 /turf/simulated/floor/carpet/red,
 /area/liberia/captain)
 "np" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/blue{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/bar)
@@ -7117,6 +7105,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/dockinghall)
+"rl" = (
+/obj/structure/sign/poster,
+/turf/simulated/wall/prepainted,
+/area/liberia/personellroom2)
 "rn" = (
 /obj/structure/table/rack{
 	dir = 8
@@ -7358,6 +7350,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
+"tj" = (
+/obj/machinery/alarm/merchant{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/reagentgrinder/juicer,
+/turf/simulated/floor/tiled/freezer,
+/area/liberia/bar)
 "to" = (
 /obj/structure/table/rack/dark,
 /obj/random/loot,
@@ -8229,8 +8233,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/liberia/engineeringengines)
 "IQ" = (
-/obj/structure/sign/poster,
-/turf/simulated/wall/prepainted,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/material/knife/kitchen,
+/obj/item/material/kitchen/rollingpin,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/reagent_containers/glass/beaker/bowl,
+/turf/simulated/floor/tiled/freezer,
 /area/liberia/bar)
 "Ja" = (
 /obj/structure/bed/chair/wood/walnut,
@@ -8958,6 +8969,17 @@
 /obj/effect/floor_decal/corner/green/three_quarters,
 /turf/simulated/floor/tiled,
 /area/liberia/traidingroom)
+"VR" = (
+/obj/effect/floor_decal/spline/plain/brown,
+/obj/structure/bed/padded,
+/obj/item/bedsheet/rd,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/submap_landmark/spawnpoint/liberia,
+/turf/simulated/floor/wood/ebony,
+/area/liberia/captain)
 "VS" = (
 /obj/machinery/atm{
 	pixel_y = -30
@@ -9013,6 +9035,17 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/liberia/library)
+"Wc" = (
+/obj/structure/closet/secure_closet{
+	name = "merchant's locker"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/belt/medical/emt,
+/obj/item/clothing/head/hardhat/EMS,
+/obj/item/clothing/suit/storage/toggle/fr_jacket/ems,
+/obj/item/clothing/mask/gas/half,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/liberia/merchantstorage)
 "Wn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -9097,6 +9130,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/liberia/hallway)
+"Xf" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/machinery/gibber,
+/turf/simulated/floor/tiled/freezer,
+/area/liberia/bar)
 "Xw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -26524,7 +26565,7 @@ VX
 Fc
 Aa
 gO
-hh
+VR
 no
 hE
 xc
@@ -26692,7 +26733,7 @@ aa
 aa
 aa
 aa
-aa
+iy
 iy
 aN
 aU
@@ -26730,7 +26771,7 @@ hi
 af
 hF
 Aa
-aa
+Aa
 aa
 aa
 aa
@@ -26929,9 +26970,9 @@ lu
 Aa
 gQ
 Vp
-Vp
-Vp
-Fs
+hs
+hG
+hN
 Fs
 aa
 aa
@@ -27130,10 +27171,10 @@ fO
 gf
 gr
 np
-Vp
-hs
-hG
-hN
+hj
+ht
+hH
+hO
 Fs
 aa
 aa
@@ -27332,10 +27373,10 @@ fP
 gg
 gs
 gS
-hj
-ht
-hH
-hO
+Vp
+ag
+hI
+ah
 Fs
 aa
 aa
@@ -27534,10 +27575,10 @@ fQ
 gh
 gt
 gT
+rl
 Vp
-ag
-hI
-ah
+Vp
+Vp
 Fs
 aa
 aa
@@ -27736,10 +27777,10 @@ fR
 gi
 gu
 gU
+hk
 IQ
-nQ
-nQ
-nQ
+tj
+Xf
 Uh
 aa
 aa
@@ -27938,7 +27979,7 @@ fS
 gj
 gv
 BH
-hk
+BH
 hv
 hJ
 hQ
@@ -30337,7 +30378,7 @@ jV
 to
 iB
 ae
-al
+Wc
 at
 aC
 lD

--- a/maps/away_inf/yacht/yacht.dmm
+++ b/maps/away_inf/yacht/yacht.dmm
@@ -30,9 +30,8 @@
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "ad" = (
-/obj/effect/wingrille_spawn/reinforced/full,
-/obj/effect/paint/sun,
 /obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
 /area/yacht/bridge)
 "ae" = (
@@ -43,11 +42,6 @@
 /obj/effect/shuttle_landmark/nav_yacht/nav1,
 /turf/space,
 /area/space)
-"ag" = (
-/obj/structure/catwalk,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/yacht/engine)
 "ah" = (
 /turf/simulated/wall/walnut,
 /area/yacht/bridge)
@@ -711,8 +705,8 @@
 /turf/simulated/wall/walnut,
 /area/yacht/living)
 "by" = (
-/obj/effect/wingrille_spawn/reinforced/full,
 /obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
 /area/yacht/living)
 "bz" = (
@@ -819,6 +813,7 @@
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "bJ" = (
@@ -1190,24 +1185,17 @@
 "cx" = (
 /obj/effect/submap_landmark/spawnpoint/yachtman_spawn,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	dir = 4;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	dir = 1;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	dir = 1;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cy" = (
@@ -1415,14 +1403,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass/bolted/cycling{
-	frequency = 1380;
-	id_tag = "solar_yacht_outer"
-	},
-/obj/machinery/door/airlock/external/glass/bolted/cycling{
-	frequency = 1380;
-	id_tag = "solar_yacht_outer"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1640,7 +1620,7 @@
 "de" = (
 /obj/effect/paint/sun,
 /obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced/full,
+/obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "df" = (
@@ -3068,12 +3048,6 @@
 /obj/effect/floor_decal/solarpanel,
 /turf/simulated/floor/airless,
 /area/yacht/engine)
-"UX" = (
-/obj/effect/wingrille_spawn/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/effect/paint/sun,
-/turf/simulated/floor/plating,
-/area/yacht/living)
 "YE" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3106,8 +3080,7 @@
 /turf/simulated/floor/carpet/purple,
 /area/yacht/living)
 "Zs" = (
-/obj/effect/wingrille_spawn/reinforced/full,
-/obj/effect/paint/sun,
+/obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
 /area/yacht/living)
 "ZN" = (
@@ -7442,9 +7415,9 @@ aa
 aa
 aA
 aA
-UX
-UX
-UX
+by
+by
+by
 Zs
 cc
 cc
@@ -8170,7 +8143,7 @@ Lb
 aD
 ed
 dR
-ag
+ky
 ky
 db
 Gu

--- a/maps/away_inf/yacht/yacht.dmm
+++ b/maps/away_inf/yacht/yacht.dmm
@@ -264,6 +264,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/item/stock_parts/circuitboard/gibber,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "aC" = (
@@ -697,10 +698,10 @@
 	dir = 1;
 	icon_state = "rwindow"
 	},
-/obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "bw" = (
@@ -745,6 +746,13 @@
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/shoes/slippers,
+/obj/item/clothing/shoes/slippers,
+/obj/item/clothing/under/pj/red,
+/obj/item/clothing/under/pj/blue,
+/obj/item/gun/energy/gun/small,
+/obj/item/gun/energy/gun/small,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "bD" = (
@@ -808,12 +816,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/pj/blue,
-/obj/item/clothing/under/pj/red,
-/obj/item/clothing/shoes/slippers,
-/obj/item/gun/energy/gun,
-/obj/item/clothing/shoes/slippers,
 /obj/effect/floor_decal/spline/fancy/black{
 	dir = 4
 	},
@@ -1098,6 +1100,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/closet/walllocker/firecloset{
+	pixel_y = 30
+	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cl" = (
@@ -1115,11 +1120,7 @@
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cm" = (
-/obj/structure/table/woodentable/walnut,
-/obj/item/shovel/spade,
-/obj/item/reagent_containers/misc/bucket,
-/obj/item/material/hatchet,
-/obj/item/storage/plants,
+/obj/machinery/biogenerator,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "cn" = (
@@ -1157,11 +1158,14 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 4559.63
+	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "ct" = (
@@ -1518,12 +1522,14 @@
 	icon_state = "alarm0";
 	pixel_x = 25
 	},
-/obj/structure/closet/walllocker/firecloset,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1;
 	icon_state = "map_scrubber_on"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/suit_storage_unit/engineering/salvage{
+	req_access = null
+	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "cV" = (
@@ -1548,6 +1554,14 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain/brown,
+/obj/structure/closet/walllocker{
+	pixel_x = 24;
+	pixel_y = 4
+	},
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/misc/bucket,
+/obj/item/storage/plants,
+/obj/item/material/hatchet,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/living)
 "cY" = (
@@ -1687,8 +1701,8 @@
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "dl" = (
-/obj/machinery/suit_storage_unit/engineering/salvage{
-	req_access = null
+/obj/machinery/suit_cycler{
+	req_access = list()
 	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
@@ -1709,8 +1723,8 @@
 /area/yacht/engine)
 "dn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_cycler{
-	req_access = list()
+/obj/machinery/suit_storage_unit/engineering/salvage{
+	req_access = null
 	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
@@ -1761,7 +1775,6 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/freezer,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/masks,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/syringes,
 /obj/structure/window/reinforced/tinted{
@@ -1782,6 +1795,8 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 1
 	},
+/obj/item/roller,
+/obj/item/storage/box/gloves,
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
 "dr" = (
@@ -1830,13 +1845,13 @@
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "dv" = (
-/obj/structure/bed/roller,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
 "dw" = (
@@ -1857,6 +1872,10 @@
 	pixel_x = 24;
 	pixel_y = 4
 	},
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/rescue,
+/obj/item/auto_cpr,
+/obj/item/device/scanner/health,
 /turf/simulated/floor/tiled/white,
 /area/yacht/living)
 "dy" = (
@@ -2106,7 +2125,7 @@
 	icon_state = "map"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
+/obj/machinery/vending/parts/public,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "ef" = (
@@ -2133,7 +2152,9 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/air{
+	start_pressure = s
+	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "eh" = (
@@ -2213,6 +2234,9 @@
 /obj/item/crowbar/prybar,
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)
@@ -2348,8 +2372,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/table/rack{
-	dir = 8
+/obj/machinery/space_heater,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/yacht/engine)

--- a/maps/away_inf/yacht/yacht.dmm
+++ b/maps/away_inf/yacht/yacht.dmm
@@ -2152,9 +2152,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air{
-	start_pressure = s
-	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "eh" = (


### PR DESCRIPTION
# Описание

* Изменения яхты, Либерии, Биркэт
* Исправлены недочеты 


## Основные изменения

Яхта:
* Добавлен операционный стол;
* Добавлены стерильные перчатки;
* Добавлены сканер здоровья стазис и обычный мешок спасения в ранее не использовавшийся шкафчик в медбее;
* Большой ЛАЕП заменен на два маленьких;
* Добавлена плата гиббера для разделки туш. Сделать придётся самому;
* Добавлен вендомат базовых деталей;
* Добавлен биогенератор;
* Шкафчик в ботанике, содержащий предметы, ранее лежавшие на столе;
* Добавлен второй войдсьют. Теперь два джетпака не бесполезны;
* Мелкие правки расположения и красоты в двигательной;
* Исправлены множественные шлюзы на одном турфе с левого шлюза на яхте;
* Починен не заряжающийся СМЕС;
* Обычные окна заменены на нормальные окна с низкой стенкой;
* Мелкие багфиксы.

Либерия:
* Уменьшена каюта торговца;
* Слегка расширена кухня, добавлен блендер, гиббер, миска для смешивания;
* Добавлены шлем и плитник на Мул. Тактическая плита больше не бесполезна при неудачных торговых предложениях!
* Добавлены наборы одежды и инструментов инженера и медика в пустые шкафчики торговцев на склад;
* Гитара с невидимым спрайтом на Муле заменена на нормальную;
* Заполнена кофемашина в торговой зоне;
* Добавлен алкоголь в бар;

Биркэт:
* Удалена непонятная кровать на складе инструментов верхней палубы;
* Раздатчик инструментов перенесен на верхнюю палубу, к шкафчикам с инструментами;
* На место раздатчика поставлен Suit Cycler;


## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
maptweak: изменена яхта
maptweak: изменена Либерия
maptweak: изменен Биркэт
/:cl:
