### PR TITLE
Move `last_vote` timer to the end of the vote

### DIFF
--- a/code/datums/vote/manual_transfer.dm
+++ b/code/datums/vote/manual_transfer.dm
@@ -31,7 +31,6 @@
 
 /datum/vote/transfer_manual/setup_vote(mob/creator, automatic)
 	choices = list(CHOICE_TRANSFER, CHOICE_EXTEND)
-	last_vote = world.time
 	..()
 
 /datum/vote/transfer_manual/tally_result()
@@ -75,6 +74,7 @@
 /datum/vote/transfer_manual/report_result()
 	if(..())
 		return 1
+	last_vote = world.time
 	if(result[1] == CHOICE_TRANSFER)
 		init_autotransfer()
 


### PR DESCRIPTION
Почему-то пока он там находится, всё ломается. Понятия не имею как оно сломалось, но проще сделать иначе и с уверенностью что так точно заработает, чем разбираться в проблеме.