### PR TITLE
Fixes IAA Office

### DIFF
--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -14388,7 +14388,8 @@
 /obj/structure/closet/secure_closet/walllocker/secure{
 	name = "High-Risk Papers";
 	req_access = list("ACCESS_IAA");
-	pixel_x = 28
+	pixel_x = 28;
+	anchored = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -22664,7 +22665,8 @@
 /obj/structure/closet/secure_closet/walllocker/secure{
 	name = "Prisoners cutlery";
 	pixel_y = -30;
-	wall_mounted = 1
+	wall_mounted = 1;
+	anchored = 1
 	},
 /obj/item/material/knife/table/plastic,
 /obj/item/material/knife/table/plastic,
@@ -42233,7 +42235,7 @@
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Miscellaneous Test Chamber";
 	dir = 8;
-	network = list("Research","Miscellaneous Reseach")
+	network = list("Research","Miscellaneous  Reseach")
 	},
 /obj/machinery/air_sensor{
 	id_tag = "testchamber_sensor"

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -10586,7 +10586,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/firstdeck/centralstarboard)
 "arz" = (
-/turf/simulated/wall/prepainted,
+/turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/iaa)
 "arA" = (
 /turf/simulated/wall/r_wall/hull,
@@ -14413,7 +14413,7 @@
 /area/turret_protected/ai_cyborg_station)
 "azV" = (
 /obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/prepainted,
+/turf/simulated/wall/r_wall/prepainted,
 /area/crew_quarters/heads/office/iaa)
 "azW" = (
 /obj/machinery/door/firedoor,
@@ -38442,6 +38442,9 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/heads/office/hop)
+"gGv" = (
+/turf/simulated/wall/r_wall/prepainted,
+/area/engineering/auxpower)
 "gHs" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
@@ -42230,7 +42233,7 @@
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Miscellaneous Test Chamber";
 	dir = 8;
-	network = list("Research","Miscellaneous  Reseach")
+	network = list("Research","Miscellaneous    Reseach")
 	},
 /obj/machinery/air_sensor{
 	id_tag = "testchamber_sensor"
@@ -61959,11 +61962,11 @@ aaB
 ahG
 rcG
 ajY
-ald
-ald
-ald
-ald
-ald
+gGv
+gGv
+gGv
+gGv
+gGv
 arz
 arz
 vkZ

--- a/maps/sierra/sierra-3.dmm
+++ b/maps/sierra/sierra-3.dmm
@@ -42233,7 +42233,7 @@
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Miscellaneous Test Chamber";
 	dir = 8;
-	network = list("Research","Miscellaneous    Reseach")
+	network = list("Research","Miscellaneous Reseach")
 	},
 /obj/machinery/air_sensor{
 	id_tag = "testchamber_sensor"


### PR DESCRIPTION
# Описание

Как обычно в самый актуальный момент выяснилось, что кое-что важное было упущенно. А именно укрепленные стены вместо обычных.
Antags shall not pass.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Neonvolt
bugfix: replaced regualar walls with reinforced ones in the IAA Office
/:cl:
