### PR TITLE
fix civ space helmet tint

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -77,30 +77,14 @@
 
 /obj/item/clothing/head/helmet/space/proc/update_tint()
 	if(tinted)
-/* [ORIG]
 		icon_state = "[initial(icon_state)]_dark"
 		item_state = "[initial(item_state)]_dark"
-[/ORIG] */
-
-// [INF] BS12 orig variant breaks helmet's sprites ~ SidVeld
-		icon_state = "[icon_state]_dark"
-		item_state = "[item_state]_dark"
-// [/INF]
-
 		flash_protection = FLASH_PROTECTION_MAJOR
 		flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 		tint = TINT_MODERATE
 	else
-/* [ORIG]
 		icon_state = initial(icon_state)
 		item_state = initial(item_state)
-[/ORIG] */
-
-// [INF] BS12 orig variant breaks helmet's sprites ~ SidVeld
-		icon_state = replacetext(icon_state, "_dark", "")
-		item_state = replacetext(item_state, "_dark", "")
-// [/INF]
-
 		flash_protection = FLASH_PROTECTION_NONE
 		flags_inv = HIDEEARS|BLOCKHAIR
 		tint = TINT_NONE


### PR DESCRIPTION
Небольшой фикс затемнения визора на гражданском белом космошлеме. По какой-то причине Сид сделал то что он сделал, но по иронии, его фикс ломает затемнение на спрайтах. 

Проверил остальные шлемы с затемнением визора, ничего не отвалилось. Спрайты на месте.


:cl:
bugfix: затемнение визора на гражданском шлеме больше не заставляет спрайт пропасть
/:cl:
