### PR TITLE
Fix empty items appear in loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -25,6 +25,8 @@ var/list/gear_datums = list()
 			continue
 		if(GLOB.using_map.loadout_blacklist && (geartype in GLOB.using_map.loadout_blacklist))
 			continue
+		if(!length_char(initial(G.display_name)))
+			continue
 
 		var/use_name = initial(G.display_name)
 		var/use_category = initial(G.sort_category)


### PR DESCRIPTION
# Описание

Теперь в список предметов лоадаута не добавляются предметы с пустым названием

fixes #497

## Скриншоты

| Было                   | Стало                  |
| ---------------------- | ---------------------- |
| ![218135075-776f66bd-ea0b-4995-820e-3be09e12fdab](https://github.com/ss220-space/Baystation12/assets/147109479/9181f296-eb23-432a-b405-4cfcd0ffe5c6) | ![image](https://github.com/ss220-space/Baystation12/assets/147109479/a80fad5e-a844-4e76-bdf3-3edb23645462) |

## Changelog

:cl:
bugfix: В лоадауте больше не появляются пустые предметы
/:cl: