### PR TITLE
Tweaks 5th Fleet Centcomm

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(adminfaxes) //cache for faxes that have been sent to admins
 	insert_anim = "faxsend"
 	var/send_access = list(list(access_lawyer, access_bridge, access_armory, access_qm, access_heads, access_cent_general))
 
-	var/static/list/admin_departments = list("[GLOB.using_map.boss_name]", "Command of the 5th Fleet", "Sol Governmental Authority", "Sol-Gov Job Boards", "Sol-Gov Supply Departament", "FTU Agency")
+	var/static/list/admin_departments = list("[GLOB.using_map.boss_name]", "SFV Stinger Command Departament", "Sol Governmental Authority", "Sol-Gov Job Boards", "Sol-Gov Supply Departament", "FTU Agency")
 
 
 	idle_power_usage = 30

--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -113,7 +113,6 @@
 	branch = /datum/mil_branch/fleet
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/o4,
 		/datum/mil_rank/fleet/o3
 	)
 	supervisors = "Command of the Battle Group Bravo of the 5th fleet, SCGDF"
@@ -230,7 +229,10 @@
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/fleet/o4
+		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/fleet/o6,
+		/datum/mil_rank/fleet/o7
 	)
 	spawn_rank_types = list(
 		/datum/mil_rank/fleet/e4,
@@ -239,7 +241,10 @@
 		/datum/mil_rank/fleet/o1,
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/fleet/o3,
-		/datum/mil_rank/fleet/o4
+		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/fleet/o6,
+		/datum/mil_rank/fleet/o7
 	)
 
 /datum/mil_rank/grade()
@@ -291,6 +296,24 @@
 	name_short = "LCDR"
 	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4, /obj/item/clothing/accessory/solgov/specialty/officer)
 	sort_order = 14
+
+/datum/mil_rank/fleet/o5
+	name = "Commander"
+	name_short = "CDR"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o5, /obj/item/clothing/accessory/solgov/specialty/officer)
+	sort_order = 15
+
+/datum/mil_rank/fleet/o6
+	name = "Captain"
+	name_short = "CAPT"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6, /obj/item/clothing/accessory/solgov/specialty/officer)
+	sort_order = 16
+
+/datum/mil_rank/fleet/o7
+	name = "Commodore"
+	name_short = "CDRE"
+	accessory = list(/obj/item/clothing/accessory/solgov/rank/fleet/flag, /obj/item/clothing/accessory/solgov/specialty/officer)
+	sort_order = 17
 
 /datum/mil_branch/army
 	name = "SCG Army"

--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -432,24 +432,26 @@
 /decl/hierarchy/outfit/job/patrol/centcom/bridge_officer
 	name = PATROL_OUTFIT_JOB_NAME("Bridge Officer")
 	head = /obj/item/clothing/head/beret/solgov/fleet/branch/fifth
+	r_ear = /obj/item/device/radio/headset/away_scg_patrol
 	l_ear = /obj/item/device/radio/headset/headset_com/alt
 	uniform = /obj/item/clothing/under/solgov/service/fleet
 	belt = /obj/item/storage/belt/holster/general/away_solpatrol
 	shoes = /obj/item/clothing/shoes/dress
-	suit = /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/bridge_officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/fleet/officer/away_solpatrol
 	r_pocket = /obj/item/card/id/syndicate
-	l_pocket = /obj/item/clothing/accessory/solgov/rank/fleet/officer
+	l_pocket = /obj/item/clothing/head/solgov/dress/fleet/command
 	id_types = list(/obj/item/card/id/centcom/NtPass/station)
 	id_pda_assignment = "5th Fleet Bridge Officer"
 
 /decl/hierarchy/outfit/job/patrol/centcom/comms_officer
 	name = PATROL_OUTFIT_JOB_NAME("Communications Officer")
-	head = /obj/item/clothing/head/solgov/dress/fleet
+	head = /obj/item/clothing/head/solgov/dress/fleet/command
+	r_ear = /obj/item/device/radio/headset/away_scg_patrol
 	l_ear = /obj/item/device/radio/headset/headset_com/alt
 	uniform = /obj/item/clothing/under/solgov/service/fleet
 	belt = /obj/item/storage/belt/holster/general/away_solpatrol
 	shoes = /obj/item/clothing/shoes/dress
-	suit = /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/comms_officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/fleet/officer/away_solpatrol
 	r_pocket = /obj/item/card/id/syndicate
 	l_pocket = /obj/item/clothing/head/beret/solgov/fleet/command
 	id_types = list(/obj/item/card/id/centcom/NtPass/station)
@@ -458,12 +460,13 @@
 /decl/hierarchy/outfit/job/patrol/centcom/commanding_officer
 	name = PATROL_OUTFIT_JOB_NAME("Commanding Officer")
 	head = /obj/item/clothing/head/solgov/dress/fleet/command
+	r_ear = /obj/item/device/radio/headset/away_scg_patrol
+	l_ear = /obj/item/device/radio/headset/headset_com/alt
 	uniform = /obj/item/clothing/under/solgov/service/fleet
 	belt = /obj/item/storage/belt/holster/general/away_solpatrol
 	shoes = /obj/item/clothing/shoes/dress
-	suit = /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/commanding_officer
+	suit = /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol
 	r_pocket = /obj/item/card/id/syndicate
-	l_pocket = /obj/item/clothing/accessory/solgov/rank/fleet/flag
 	id_types = list(/obj/item/card/id/centcom/NtPass/station)
 	id_pda_assignment = "5th Fleet Commanding Officer"
 

--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -58,9 +58,9 @@
 	branch = /datum/mil_branch/army
 	allowed_branches = list(/datum/mil_branch/army)
 	allowed_ranks = list(
-		/datum/mil_rank/army/e5,
 		/datum/mil_rank/army/e4,
-		/datum/mil_rank/army/e4_alt
+		/datum/mil_rank/army/e4_alt,
+		/datum/mil_rank/army/e5
 	)
 	supervisors = "Army SCGSO Leader"
 	loadout_allowed = TRUE
@@ -86,8 +86,8 @@
 	branch = /datum/mil_branch/army
 	allowed_branches = list(/datum/mil_branch/army)
 	allowed_ranks = list(
-		/datum/mil_rank/army/o3,
-		/datum/mil_rank/army/o2
+		/datum/mil_rank/army/o2,
+		/datum/mil_rank/army/o3
 	)
 	supervisors = "Fleet Commander, Command of the Battle Group Bravo of the 5th fleet, SCGDF"
 	loadout_allowed = TRUE
@@ -137,8 +137,8 @@
 	branch = /datum/mil_branch/fleet
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/o2,
-		/datum/mil_rank/fleet/o1
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2
 	)
 	supervisors = "Fleet Commander"
 	loadout_allowed = TRUE
@@ -190,9 +190,9 @@
 	branch = /datum/mil_branch/fleet
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/e6,
+		/datum/mil_rank/fleet/e4,
 		/datum/mil_rank/fleet/e5,
-		/datum/mil_rank/fleet/e4
+		/datum/mil_rank/fleet/e6
 	)
 	supervisors = "Fleet Pilot, Fleet Commander"
 	loadout_allowed = TRUE

--- a/maps/away_inf/sentinel/sentinel_crew.dm
+++ b/maps/away_inf/sentinel/sentinel_crew.dm
@@ -113,7 +113,8 @@
 	branch = /datum/mil_branch/fleet
 	allowed_branches = list(/datum/mil_branch/fleet)
 	allowed_ranks = list(
-		/datum/mil_rank/fleet/o3
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4
 	)
 	supervisors = "Command of the Battle Group Bravo of the 5th fleet, SCGDF"
 	loadout_allowed = TRUE

--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -99,19 +99,13 @@
 		/obj/item/clothing/accessory/solgov/fleet_patch/fifth
 	)
 
-/obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/bridge_officer
+/obj/item/clothing/suit/storage/solgov/service/fleet/officer/away_solpatrol
 	starting_accessories = list(
 		/obj/item/clothing/accessory/chameleon,
 		/obj/item/clothing/accessory/solgov/specialty/officer
 	)
 
-/obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/comms_officer
-	starting_accessories = list(
-		/obj/item/clothing/accessory/chameleon,
-		/obj/item/clothing/accessory/solgov/specialty/officer
-	)
-
-/obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/commanding_officer
+/obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol
 	starting_accessories = list(
 		/obj/item/clothing/accessory/chameleon,
 		/obj/item/clothing/accessory/solgov/specialty/officer

--- a/maps/away_inf/sentinel/sentinel_items.dm
+++ b/maps/away_inf/sentinel/sentinel_items.dm
@@ -101,19 +101,19 @@
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/bridge_officer
 	starting_accessories = list(
-		/obj/item/clothing/accessory/solgov/rank/fleet/officer/o2,
+		/obj/item/clothing/accessory/chameleon,
 		/obj/item/clothing/accessory/solgov/specialty/officer
 	)
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/comms_officer
 	starting_accessories = list(
-		/obj/item/clothing/accessory/solgov/rank/fleet/officer/o4,
+		/obj/item/clothing/accessory/chameleon,
 		/obj/item/clothing/accessory/solgov/specialty/officer
 	)
 
 /obj/item/clothing/suit/storage/solgov/service/fleet/command/away_solpatrol/commanding_officer
 	starting_accessories = list(
-		/obj/item/clothing/accessory/solgov/rank/fleet/officer/o6,
+		/obj/item/clothing/accessory/chameleon,
 		/obj/item/clothing/accessory/solgov/specialty/officer
 	)
 

--- a/maps/sierra/sierra-4.dmm
+++ b/maps/sierra/sierra-4.dmm
@@ -17530,7 +17530,9 @@
 "rSU" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/black/mono,
-/obj/machinery/photocopier/faxmachine/centcomm,
+/obj/machinery/photocopier/faxmachine/centcomm{
+	department = "SFV Stinger Command Departament"
+	},
 /turf/unsimulated/floor/techfloor{
 	icon_state = "monotiledark";
 	icon = 'icons/turf/flooring/tiles.dmi'


### PR DESCRIPTION
# Описание

Небольшие изменения, связанные с патрулькой ЦПСС.

## Основные изменения

* Небольшие изменения админских пресетов формы для Флота.
* Адресат ЦК патрульки теперь имеет более корректное название.
* Перевернул ранги, чтобы в настройках должностей автоматически выставлялось самое младшее звание, а не высокое, как раньше.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: renamed 5th Fleet Centcomm
tweak: Fleet default rank is now the lowest one
admin: edited some Fleet outfit presets
/:cl:
