### PR TITLE
Hides Spy Station from Navigation data

### DIFF
--- a/maps/away_inf/spy_station/spy_station.dm
+++ b/maps/away_inf/spy_station/spy_station.dm
@@ -1,8 +1,6 @@
 #include "spy_station_areas.dm"
 
 /obj/effect/overmap/visitable/sector/spy_station
-	name = "spy station"
-	desc = "spy SCG station"
 	scanner_name = "Small station"
 	scanner_desc = @{"<br>
 	<i>Registration</i>: SCGDF military facility<br>


### PR DESCRIPTION
# Описание

Довольно странно получается, что секретная шпионская станция светится на всех консолях управления полетом, как одна из точек интереса. Пусть теперь хотя бы у нее будет дефолтное название которое не будет так сильно выделятся, generic sector.
Довольно печально, что авейку можно спрятать из сканирования сектора Сьеррой, но нельзя убрать из этого пресловутого списка Navigation data, куда попадают все диреликты.

:cl: Neonvolt
maptweak: removed Spy Station name and description vars
/:cl:
