### PR TITLE
FEAT: EC rank badges for Sierra

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -399,6 +399,14 @@ SUBSYSTEM_DEF(jobs)
 					for(var/required in G.allowed_skills)
 						if(!H.skill_check(required,G.allowed_skills[required]))
 							permitted = 0
+							
+				if(permitted && G.allowed_backgrounds)
+					var/decl/cultural_info/background = H.get_cultural_value(TAG_FACTION)
+					var/bcndname = background ? background.name : "Unset"
+					if(bcndname in G.allowed_backgrounds)
+						permitted = 1
+					else
+						permitted = 0
 
 				if(G.whitelisted && (!(H.species.name in G.whitelisted)))
 					permitted = 0

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -368,6 +368,7 @@ var/list/gear_datums = list()
 	var/list/allowed_roles //Roles that can spawn with this item.
 	var/list/allowed_branches //Service branches that can spawn with it.
 	var/list/allowed_skills //Skills required to spawn with this item.
+	var/list/allowed_backgrounds //Character background required to spawn with this item.
 	var/whitelisted        //Term to check the whitelist for..
 	var/sort_category = "General"
 	var/flags              //Special tweaks in New

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -260,6 +260,22 @@ var/list/gear_datums = list()
 				skill_checks += skill_entry
 
 			entry += "[english_list(skill_checks)]</i>"
+			
+		if(allowed && G.allowed_backgrounds)
+			var/good_background = 0
+			var/decl/cultural_info/background = SSculture.get_culture(pref.cultural_info[TAG_FACTION])
+			var/bgndname = background ? background.name : "Unset"
+			entry += "<br><i>"
+			
+			var/list/backgroundchecks = list()
+			
+			if(bgndname in G.allowed_backgrounds)
+				backgroundchecks += "<font color=55cc55>[bgndname]</font>"
+				good_background = 1
+			else
+				backgroundchecks += "<font color=cc5555>[bgndname]</font>"
+			allowed = good_background
+			entry += "[english_list(backgroundchecks)]</i>"
 		//[INF]
 		entry += "<td style='[text_style]'>[G.price]"
 		entry += "<td style='[text_style]'>[G.required_donate_level]"

--- a/maps/sierra/items/clothing/accessory.dm
+++ b/maps/sierra/items/clothing/accessory.dm
@@ -1,0 +1,61 @@
+/obj/item/clothing/accessory/solgov
+	name = "master solgov accessory"
+	icon = 'maps/torch/icons/obj/obj_accessories_solgov.dmi'
+	accessory_icons = list(slot_w_uniform_str = 'maps/torch/icons/mob/onmob_accessories_solgov.dmi', slot_wear_suit_str = 'maps/torch/icons/mob/onmob_accessories_solgov.dmi')
+	w_class = ITEM_SIZE_TINY
+
+/*********
+ranks - ec
+*********/
+
+/obj/item/clothing/accessory/solgov/rank
+	name = "ranks"
+	desc = "Insignia denoting rank of some kind. These appear blank."
+	icon_state = "fleetrank"
+	on_rolled = list("down" = "none")
+	slot = ACCESSORY_SLOT_RANK
+	gender = PLURAL
+	high_visibility = 1
+	sprite_sheets = list(
+		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_accessories_sol_unathi.dmi',
+		SPECIES_RESOMI = 'infinity/icons/mob/species/resomi/onmob_accessories_resomi.dmi'
+		)
+
+/obj/item/clothing/accessory/solgov/rank/get_fibers()
+	return null
+
+/obj/item/clothing/accessory/solgov/rank/ec
+	name = "explorer ranks"
+	desc = "Insignia denoting rank of some kind. These appear blank."
+	icon_state = "ecrank_e1"
+	on_rolled = list("down" = "none")
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted
+	name = "ranks (E-1 apprentice explorer)"
+	desc = "Insignia denoting the rank of Apprentice Explorer."
+	icon_state = "ecrank_e1"
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3
+	name = "ranks (E-3 explorer)"
+	desc = "Insignia denoting the rank of Explorer."
+	icon_state = "ecrank_e3"
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5
+	name = "ranks (E-5 senior explorer)"
+	desc = "Insignia denoting the rank of Senior Explorer."
+	icon_state = "ecrank_e5"
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7
+	name = "ranks (E-7 chief explorer)"
+	desc = "Insignia denoting the rank of Chief Explorer."
+	icon_state = "ecrank_e7"
+
+/obj/item/clothing/accessory/solgov/rank/ec/officer
+	name = "ranks (O-1 ensign)"
+	desc = "Insignia denoting the rank of Ensign."
+	icon_state = "ecrank_o1"
+
+/obj/item/clothing/accessory/solgov/rank/ec/officer/o3
+	name = "ranks (O-3 lieutenant)"
+	desc = "Insignia denoting the rank of Lieutenant."
+	icon_state = "ecrank_o3"

--- a/maps/sierra/loadout/loadout_accessories.dm
+++ b/maps/sierra/loadout/loadout_accessories.dm
@@ -52,6 +52,24 @@
 	allowed_roles = list(/datum/job/submap/merchant, /datum/job/submap/merchant_trainee, /datum/job/assistant)
 	allowed_branches = list(/datum/mil_branch/civilian)
 
+/datum/gear/accessory/solgov_ec_rank
+	display_name = "Expeditionary Corps rank badges selection"
+	description = "An insignia denoting wearer's rank within the SCG Expeditionary Corps."
+	path = /obj/item/clothing/accessory
+	allowed_branches = list(/datum/mil_branch/contractor)
+	allowed_backgrounds = list(FACTION_SOL_CENTRAL, FACTION_EXPEDITIONARY, FACTION_CORPORATE)
+
+/datum/gear/accessory/solgov_ec_rank/New()
+	..()
+	var/solgovranks = list()
+	solgovranks["ranks (E-1 apprentice explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted
+	solgovranks["ranks (E-3 explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3
+	solgovranks["ranks (E-5 senior explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5
+	solgovranks["ranks (E-7 chief explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7
+	solgovranks["ranks (O-1 ensign)"] = /obj/item/clothing/accessory/solgov/rank/ec/officer
+	solgovranks["ranks (O-3 lieutenant)"] = /obj/item/clothing/accessory/solgov/rank/ec/officer/o3
+	gear_tweaks += new/datum/gear_tweak/path(solgovranks)
+
 /datum/gear/passport/scg
 	display_name = "passports selection - SCG"
 	description = "A selection of SCG passports."

--- a/maps/sierra/sierra.dm
+++ b/maps/sierra/sierra.dm
@@ -56,6 +56,7 @@
 	#include "items/rigs.dm"
 	#include "items/stamps.dm"
 
+	#include "items/clothing/accessory.dm"
 	#include "items/clothing/clothing.dm"
 	#include "items/clothing/exploration.dm"
 	#include "items/clothing/override.dm"


### PR DESCRIPTION
# Описание

ПР делает что-то умное. Конкретно - добавляет функцию сверки выбранной для персонажа фракции для предметов лодаута, а также портирует значки ЭК ЦПСС с Торча, что пользуются этой самой функцией.

## Основные изменения

* Добавляет ранговые значки ЭК ЦПСС в лодаут Сьерры. 
* Добавляет новую функцию проверки предмета в лодауте - на соответствие фракции, выбранной на экране бэкграунда.
* Таким образом, новые значки доступны при выборе фракций ЦПСС, ЭК или EXO.

## Скриншоты

![image](https://github.com/ss220-space/Baystation12/assets/52104104/42be233c-7b35-4c08-be3b-6007b98e71ad)
![image](https://github.com/ss220-space/Baystation12/assets/52104104/2377cfe0-a5e9-4a14-8300-887074ee12a9)
![image](https://github.com/ss220-space/Baystation12/assets/52104104/eec83f8a-df41-4e2c-964b-b689acb24da8)

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
rscadd: Introduced faction-locked loadout items.
rscadd: Ported SCG EC rank badges to Sierra, locked for SCG, EC and EXO factions.
/:cl:
