### PR TITLE
Поднятие цен на стоймость печати combat heavy light мехов

### DIFF
--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -19,13 +19,13 @@
 
 	var/speed = 1
 	var/mat_efficiency = 1
-	
+
 /* [ORIG]
 	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 [/ORIG] */
-	
+
 // [INF]
-	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
+	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_PLASTEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 	var/res_max_amount = 200000
 // [/INF]
 
@@ -300,14 +300,17 @@
 	switch(material)
 		if(MATERIAL_STEEL)
 			mattype = /obj/item/stack/material/steel
-			
-// [INF]	
+		if(MATERIAL_PLASTEEL)
+			mattype = /obj/item/stack/material/plasteel
+
+// [INF]
 		if(MATERIAL_TITANIUM)
 			mattype = /obj/item/stack/material/titanium
 // [/INF]
-		
+
 		if(MATERIAL_GLASS)
 			mattype = /obj/item/stack/material/glass
+
 		if(MATERIAL_ALUMINIUM)
 			mattype = /obj/item/stack/material/aluminium
 		if(MATERIAL_PLASTIC)

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -116,7 +116,7 @@
 	id = "mech_frame"
 	build_path = /obj/structure/heavy_vehicle_frame
 	time = 70
-	materials = list(MATERIAL_STEEL = 20000)
+	materials = list(MATERIAL_STEEL = 60000, MATERIAL_PLASTEEL = 10000)
 	category = "Exosuits"
 
 /datum/design/item/mechfab/exosuit/basic_armour
@@ -124,7 +124,7 @@
 	id = "mech_armour_basic"
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit
 	time = 30
-	materials = list(MATERIAL_STEEL = 7500)
+	materials = list(MATERIAL_STEEL = 20000)
 
 /datum/design/item/mechfab/exosuit/radproof_armour
 	name = "radiation-proof exosuit armour"
@@ -132,7 +132,7 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/radproof
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 12500)
+	materials = list(MATERIAL_STEEL = 30000)
 
 /datum/design/item/mechfab/exosuit/em_armour
 	name = "EM-shielded exosuit armour"
@@ -140,7 +140,7 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/em
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 12500, MATERIAL_SILVER = 1000)
+	materials = list(MATERIAL_STEEL = 25000, MATERIAL_SILVER = 5000, MATERIAL_PLASTEEL = 1000)
 
 /datum/design/item/mechfab/exosuit/combat_armour
 	name = "Combat exosuit armour"
@@ -148,20 +148,20 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/combat
 	time = 50
 	req_tech = list(TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 20000, MATERIAL_DIAMOND = 5000)
+	materials = list(MATERIAL_STEEL = 60000, MATERIAL_DIAMOND = 5000, MATERIAL_PLASTEEL = 5000)
 
 /datum/design/item/mechfab/exosuit/control_module
 	name = "exosuit control module"
 	id = "mech_control_module"
 	build_path = /obj/item/mech_component/control_module
 	time = 15
-	materials = list(MATERIAL_STEEL = 5000)
+	materials = list(MATERIAL_STEEL = 60000)
 
 /datum/design/item/mechfab/exosuit/combat_torso
 	name = "combat exosuit chassis"
 	id = "combat_body"
 	time = 60
-	materials = list(MATERIAL_STEEL = 45000)
+	materials = list(MATERIAL_STEEL = 100000, MATERIAL_PLASTEEL = 9000)
 	build_path = /obj/item/mech_component/chassis/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -169,7 +169,7 @@
 	name = "combat exosuit manipulators"
 	id = "combat_arms"
 	time = 30
-	materials = list(MATERIAL_STEEL = 15000)
+	materials = list(MATERIAL_STEEL = 45000, MATERIAL_PLASTEEL = 5000)
 	build_path = /obj/item/mech_component/manipulators/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -177,7 +177,7 @@
 	name = "combat exosuit motivators"
 	id = "combat_legs"
 	time = 30
-	materials = list(MATERIAL_STEEL = 15000)
+	materials = list(MATERIAL_STEEL = 45000, MATERIAL_PLASTEEL = 5000)
 	build_path = /obj/item/mech_component/propulsion/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -213,7 +213,7 @@
 	name = "light exosuit sensors"
 	id = "light_head"
 	time = 20
-	materials = list(MATERIAL_STEEL = 8000)
+	materials = list(MATERIAL_STEEL = 12000)
 	build_path = /obj/item/mech_component/sensors/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -221,7 +221,7 @@
 	name = "light exosuit chassis"
 	id = "light_body"
 	time = 40
-	materials = list(MATERIAL_STEEL = 30000)
+	materials = list(MATERIAL_STEEL = 45000)
 	build_path = /obj/item/mech_component/chassis/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -229,7 +229,7 @@
 	name = "light exosuit manipulators"
 	id = "light_arms"
 	time = 20
-	materials = list(MATERIAL_STEEL = 10000)
+	materials = list(MATERIAL_STEEL = 15000)
 	build_path = /obj/item/mech_component/manipulators/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -237,7 +237,7 @@
 	name = "light exosuit motivators"
 	id = "light_legs"
 	time = 25
-	materials = list(MATERIAL_STEEL = 10000)
+	materials = list(MATERIAL_STEEL = 15000)
 	build_path = /obj/item/mech_component/propulsion/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -245,7 +245,7 @@
 	name = "heavy exosuit sensors"
 	id = "heavy_head"
 	time = 35
-	materials = list(MATERIAL_STEEL = 16000)
+	materials = list(MATERIAL_STEEL = 50000, MATERIAL_PLASTEEL = 10000)
 	build_path = /obj/item/mech_component/sensors/heavy
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -253,28 +253,28 @@
 	name = "heavy exosuit chassis"
 	id = "heavy_body"
 	time = 75
-	materials = list(MATERIAL_STEEL = 70000, MATERIAL_URANIUM = 10000)
+	materials = list(MATERIAL_STEEL = 180000, MATERIAL_URANIUM = 10000, MATERIAL_PLASTEEL = 20000) //Иначе совсем перебор
 	build_path = /obj/item/mech_component/chassis/heavy
 
 /datum/design/item/mechfab/exosuit/heavy_arms
 	name = "heavy exosuit manipulators"
 	id = "heavy_arms"
 	time = 35
-	materials = list(MATERIAL_STEEL = 20000)
+	materials = list(MATERIAL_STEEL = 100000, MATERIAL_PLASTEEL = 20000)
 	build_path = /obj/item/mech_component/manipulators/heavy
 
 /datum/design/item/mechfab/exosuit/heavy_legs
 	name = "heavy exosuit motivators"
 	id = "heavy_legs"
 	time = 35
-	materials = list(MATERIAL_STEEL = 20000)
+	materials = list(MATERIAL_STEEL = 100000, MATERIAL_PLASTEEL = 19000)
 	build_path = /obj/item/mech_component/propulsion/heavy
 
 /datum/design/item/mechfab/exosuit/spider
 	name = "quadruped motivators"
 	id = "quad_legs"
 	time = 20
-	materials = list(MATERIAL_STEEL = 12000)
+	materials = list(MATERIAL_STEEL = 60000)
 	build_path = /obj/item/mech_component/propulsion/spider
 	req_tech = list(TECH_ENGINEERING = 2)
 
@@ -282,7 +282,7 @@
 	name = "armored treads"
 	id = "treads"
 	time = 35
-	materials = list(MATERIAL_STEEL = 25000)
+	materials = list(MATERIAL_STEEL = 70000)
 	build_path = /obj/item/mech_component/propulsion/tracks
 	req_tech = list(TECH_MATERIAL = 4)
 
@@ -291,7 +291,7 @@
 	id = "sphere_body"
 	build_path = /obj/item/mech_component/chassis/pod
 	time = 50
-	materials = list(MATERIAL_STEEL = 18000)
+	materials = list(MATERIAL_STEEL = 60000)
 
 /datum/design/item/robot_upgrade
 	build_type = MECHFAB


### PR DESCRIPTION
В связи с прошлыми и будущими изменениями в мехах и тем фактом что комбат мех печатается за 20 листов и по математике весит...Пол тонны?...Я решил поднять цены на мехов. Посмотрим, что из этого выйдет.
1.Цены на боевые части повышаются в раза 3, у Робо даже останется листов 20 стали и пласстали
Итого: 50 листов стали 5 листов пласстали (С комбат сенсорами(Которые я попытаюсь пропихнуть когда-нибудь потом.) листов будет 47 листов стали и поменьше пласстали), вес получившейся машины без модулей: 863 кг, с комбат сенсорами 820 кг
2. Цены на тяжёлые части повышаются в раза 4, у Робо останется из стартовых материалов...да почти ничего)
Для создания потребуется 70 листов стали, 10 листов пласстали и 10 любых листов для обшивки
Пум-пум-пум.