### PR TITLE
Feat: assorted loadout changes

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -19,6 +19,10 @@
 	display_name = "tape recorder"
 	path = /obj/item/device/taperecorder
 
+/datum/gear/utility/crayons
+	display_name = "crayon pack"
+	path = /obj/item/storage/fancy/crayons
+
 /datum/gear/utility/folder/New()
 	..()
 	var/folders = list()

--- a/infinity/code/modules/client/preference_setup/loadout/lists/infinity.dm
+++ b/infinity/code/modules/client/preference_setup/loadout/lists/infinity.dm
@@ -84,6 +84,8 @@
 	corpsi["Morpheus uniform"]			= /obj/item/clothing/under/morpheus
 	corpsi["Skinner uniform"]			= /obj/item/clothing/under/skinner
 	corpsi["DAIS uniform"]				= /obj/item/clothing/under/dais
+	corpsi["SCG EC uniform"]			= /obj/item/clothing/under/solgov/utility/expeditionary
+	corpsi["SCG EC officer's uniform"]	= /obj/item/clothing/under/solgov/utility/expeditionary/officer
 	gear_tweaks += new/datum/gear_tweak/path(corpsi)
 
 

--- a/maps/sierra/loadout/loadout_accessories.dm
+++ b/maps/sierra/loadout/loadout_accessories.dm
@@ -65,9 +65,7 @@
 	solgovranks["ranks (E-1 apprentice explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted
 	solgovranks["ranks (E-3 explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3
 	solgovranks["ranks (E-5 senior explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5
-	solgovranks["ranks (E-7 chief explorer)"] = /obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7
 	solgovranks["ranks (O-1 ensign)"] = /obj/item/clothing/accessory/solgov/rank/ec/officer
-	solgovranks["ranks (O-3 lieutenant)"] = /obj/item/clothing/accessory/solgov/rank/ec/officer/o3
 	gear_tweaks += new/datum/gear_tweak/path(solgovranks)
 
 /datum/gear/passport/scg

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -53,7 +53,7 @@
 		)
 
 /obj/item/clothing/under/solgov/utility/expeditionary
-	name = "expeditionary uniform"
+	name = "Expeditionary Corps uniform"
 	desc = "The utility uniform of the SCG Expeditionary Corps, made from biohazard resistant material. This one has silver trim."
 	icon_state = "blackutility_crew"
 	worn_state = "blackutility_crew"
@@ -62,7 +62,7 @@
 		)
 
 /obj/item/clothing/under/solgov/utility/expeditionary_skirt
-	name = "expeditionary skirt"
+	name = "Expeditionary Corps skirt"
 	desc = "A black turtleneck and skirt, the elusive ladies' uniform of the Expeditionary Corps."
 	icon_state = "blackservicefem"
 	worn_state = "blackservicefem"
@@ -71,7 +71,7 @@
 		)
 
 /obj/item/clothing/under/solgov/utility/expeditionary_skirt/officer
-	name = "expeditionary officer skirt"
+	name = "Expeditionary Corps officer skirt"
 	desc = "A black turtleneck and skirt, the elusive ladies' uniform of the Expeditionary Corps. This one has gold trim."
 	icon_state = "blackservicefem_com"
 	worn_state = "blackservicefem_com"
@@ -101,7 +101,7 @@
 	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/research)
 
 /obj/item/clothing/under/solgov/utility/expeditionary/officer
-	name = "expeditionary officer's uniform"
+	name = "Expeditionary Corps officer's uniform"
 	desc = "The utility uniform of the SCG Expeditionary Corps, made from biohazard resistant material. This one has gold trim."
 	icon_state = "blackutility_com"
 	worn_state = "blackutility_com"


### PR DESCRIPTION
# Описание

ПР делает что-то умное. Конкретно - пачку изменений для лодаута, связанных с прошедшим авоутом и одобренными ГА дополнениями.

## Основные изменения

* Добавлен набор мелков в лодаут
* Добавлена форма ЭК к выбору форм контрактников
* Удалены лишние планки рангов ЭК

## Скриншоты

![image](https://github.com/ss220-space/Baystation12/assets/52104104/d62409b2-5526-48e8-8283-a3b02a1ddd1a)
![image](https://github.com/ss220-space/Baystation12/assets/52104104/457b8495-429f-4878-b901-ea911c78529d)
![image](https://github.com/ss220-space/Baystation12/assets/52104104/9f0774f3-5c2f-44ef-a96a-5e011be6a1d9)

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: Removed redundant EC rank badges (E-7 and O-3)
rscadd: Added crayon pack into loadout
rscadd: Added new contractor uniforms
/:cl:
