### PR TITLE
Glare Dampeners fix

### DIFF
--- a/code/modules/augment/active/glare_dampeners.dm
+++ b/code/modules/augment/active/glare_dampeners.dm
@@ -4,7 +4,6 @@
 	icon_state = "glare_dampeners"
 	desc = "Thick, tinted lenses installed in your head can deploy over your eyes, reducing visibility but providing protection from welding glare and bright lights."
 	action_button_name = "Deploy dampeners"
-	augment_flags = AUGMENTATION_ORGANIC
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 2)
 	equip_slot = slot_glasses
 	holding_type = /obj/item/clothing/glasses/glare_dampeners


### PR DESCRIPTION
# Описание

* Позволяет аугментации Glare Dampeners работать как вероятнее всего было задумано
* У нас длительное время встроенные сварочные линзы могли использоваться исключительно для мясных тел и взъезжать исключительно в череп. Оно должно работать и с ППТ/ИПС, потому как отсутствие работы в них этой механики - просто удивительно.

## Основные изменения

* Изменение 1: Убран флаг "Органик" из списка для корректной работы аугментации, выравнивая с другими аугментами, что могут вставать в органику и механику


## Changelog

bugfix: ППТ и ИПСы могут теперь использовать Glare Dampeners аугментацию на равных с органиками