### PR TITLE
Autodeconstuction

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -16,7 +16,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	idle_power_usage = 30
 	active_power_usage = 2500
 	construct_state = /decl/machine_construction/default/panel_closed
-	
+
 	machine_name = "destructive analyzer"
 	machine_desc = "Breaks down objects into their component parts, gaining new information in the process. Part of an R&D network."
 
@@ -84,5 +84,9 @@ Note: Must be placed within 3 tiles of the R&D Console
 		spawn(10)
 			update_icon()
 			busy = 0
+
+			if (linked_console.quick_deconstruct)
+				linked_console.deconstruct(weakref(user))
+
 		return 1
 	return

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -66,6 +66,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
 	var/can_analyze = TRUE //If the console is allowed to use destructive analyzers
+	var/quick_deconstruct = FALSE
 
 	req_access = list(access_research)	//Data and setting manipulation requires scientist access.
 
@@ -462,6 +463,17 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				screen = ((text2num(href_list["print"]) == 2) ? 5.0 : 1.1)
 				interact(user)
 
+	else if (href_list["decon_mode"])
+		quick_deconstruct = !quick_deconstruct
+		interact(user)
+
+/obj/machinery/computer/rdconsole/proc/deconstruct(weakref/W)
+	linked_destroy.busy = TRUE
+	if (!quick_deconstruct)
+		screen = 0.1
+	linked_destroy.icon_state = "d_analyzer_process"
+	addtimer(CALLBACK(src, .proc/finish_deconstruct, W), 24)
+
 /obj/machinery/computer/rdconsole/proc/finish_deconstruct(weakref/W)
 	CHECK_DESTROY
 	var/mob/user = W.resolve()
@@ -495,7 +507,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				linked_destroy.icon_state = "d_analyzer"
 
 	use_power_oneoff(linked_destroy.active_power_usage)
-	screen = 1.0
+	if (!quick_deconstruct)
+		screen = 1.0
 	if(CanInteract(user, DefaultTopicState()))
 		interact(user)
 
@@ -706,16 +719,19 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "</UL>"
 
 		////////////////////DESTRUCTIVE ANALYZER SCREENS////////////////////////////
+
 		if(2.0)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += "NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE<BR><BR>"
 
 		if(2.1)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='?src=\ref[src];decon_mode=1'>Automatic Deconstruction: [quick_deconstruct ? "ON" : "OFF"]</A><HR>"
 			dat += "No Item Loaded. Standing-by...<BR><HR>"
 
 		if(2.2)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
+			dat += "<A href='?src=\ref[src];decon_mode=1'>Automatic Deconstruction: [quick_deconstruct ? "ON" : "OFF"]</A><HR>"
 			dat += "Deconstruction Menu<HR>"
 			dat += "Name: [linked_destroy.loaded_item.name]<BR>"
 


### PR DESCRIPTION
# Описание

Кнопка включения и отключения авторазбора в deconstructore РнД.
Взято с СБея
## Основные изменения

Кнопка авторазбора в дестрактор анализаторе РНД
Теперь не надо жать мильён раз одну кнопку

## Скриншоты

![image](https://github.com/ss220-space/Baystation12/assets/61974560/71e58dfa-5193-4eb3-b5cf-f52b429c088a)

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl: Lexanx
tweak: Добавлена кнопка
/:cl:
