### PR TITLE
Твик для Тулл Белта

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -136,7 +136,10 @@
 		/obj/item/tape_roll,
 		/obj/item/clothing/head/beret,
 		/obj/item/material/knife/folding/,
-		/obj/item/welder_tank
+		/obj/item/welder_tank,
+		/obj/item/device/paint_sprayer,
+		/obj/item/rcd,
+		/obj/item/rcd_ammo
 		)
 
 
@@ -161,7 +164,13 @@
 	new /obj/item/device/t_scanner(src)
 	update_icon()
 
-
+/obj/item/storage/belt/utility/chief/New()
+	..()
+	new /obj/item/screwdriver/power(src)
+	new /obj/item/weldingtool(src)
+	new /obj/item/crowbar/power(src)
+	new /obj/item/stack/cable_coil/random(src, 30)
+	update_icon()
 
 /obj/item/storage/belt/medical
 	name = "medical belt"

--- a/maps/sierra/job/outfits.dm
+++ b/maps/sierra/job/outfits.dm
@@ -102,6 +102,7 @@ Keeping them simple for now, just spawning with basic EC uniforms, and pretty mu
 //	pda_type = /obj/item/modular_computer/pda/heads/ce
 	pda_slot = slot_l_store
 	flags = OUTFIT_FLAGS_JOB_DEFAULT | OUTFIT_EXTENDED_SURVIVAL
+	belt = /obj/item/storage/belt/utility/chief
 
 /decl/hierarchy/outfit/job/sierra/crew/command/chief_engineer/New()
 	..()


### PR DESCRIPTION
# Описание

* По решению ГА был добавлен новый префаб туллбелта и отредачен список предметов, которые можно положить в туллбелт.

## Основные изменения

* В туллбелт можно положить РЦД.
* В туллбелт можно положить заряды для РЦД.
* В туллбелт можно положить Покрасщик.
* У СЕ будет новый туллбелт при спавне.
* Туллбелт СЕ внутри себя содержит Дрель, Клещи, Сварку и Провода.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
tweak: Туллбелт теперь вмещает чуть больший список инструментов.
tweak: СЕ получил туллбелт с Тир2 инструментами при спавне.
/:cl:
