### PR TITLE
Feat: add IPC computer screen sharing and ability to use flash drives

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -168,8 +168,9 @@
 				msg += "<span class='warning'>[T.His] face is horribly mangled!</span>\n"
 		if(species.species_flags & SPECIES_ALL_ROBOPARTS)
 			var/datum/robolimb/robohead = all_robolimbs[E.model]
-			if(length(robohead.display_text) && f_style == "Text")
+			if(length(robohead.display_text) && (f_style == "Text" || f_style == "Database"))
 				msg += "Отображает на экране: [robohead.display_text]\n"
+				show_message("[user] changes image on his screen. <a HREF=?src=\ref[user];showipcscreen=\ref[src]>Take a closer look.</a>",1)
 
 	//splints
 	for(var/organ in list(BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -170,7 +170,6 @@
 			var/datum/robolimb/robohead = all_robolimbs[E.model]
 			if(length(robohead.display_text) && (f_style == "Text" || f_style == "Database"))
 				msg += "Отображает на экране: [robohead.display_text]\n"
-				show_message("[user] changes image on his screen. <a HREF=?src=\ref[user];showipcscreen=\ref[src]>Take a closer look.</a>",1)
 
 	//splints
 	for(var/organ in list(BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -557,6 +557,11 @@ GLOBAL_LIST_EMPTY(compatable_genomes_owners)
 		if(I)
 			src.examinate(I)
 			return TOPIC_HANDLED
+	if(href_list["showipcscreen"])
+		var/obj/item/modular_computer/ecs/S = locate(href_list["showipcscreen"])
+		if(S)
+			S.ui_interact(src)
+			return STATUS_UPDATE
 	return ..()
 
 /mob/living/carbon/human/CanUseTopic(mob/user, datum/topic_state/state, href_list)

--- a/code/modules/modular_computers/hardware/portable_hard_drive.dm
+++ b/code/modules/modular_computers/hardware/portable_hard_drive.dm
@@ -44,4 +44,9 @@
 /obj/item/stock_parts/computer/hard_drive/portable/attack(var/mob/living/carbon/human/H, var/mob/living/user, target_zone, animate = TRUE)
 	if(H.is_species(SPECIES_IPC) && ishuman(user) && (user.zone_sel.selecting == BP_MOUTH || user.zone_sel.selecting == BP_HEAD))
 		var/obj/item/organ/internal/ecs/T = H.internal_organs_by_name[BP_EXONET]
-		T.computer.try_install_component(user, src)
+		if (do_after(user, 10, src))
+			user.visible_message( \
+				"<span class='notice'>\The [user] install's [src] into [H]'s exonet port.</span>", \
+				"<span class='notice'>You have installed [src] into [H]'s exonet port.</span>" \
+				)
+			T.computer.try_install_component(user, src)

--- a/code/modules/modular_computers/hardware/portable_hard_drive.dm
+++ b/code/modules/modular_computers/hardware/portable_hard_drive.dm
@@ -40,3 +40,8 @@
 /obj/item/stock_parts/computer/hard_drive/portable/merchant/Initialize()
 	. = ..()
 	store_file(new/datum/computer_file/program/merchant(src))
+
+/obj/item/stock_parts/computer/hard_drive/portable/attack(var/mob/living/carbon/human/H, var/mob/living/user, target_zone, animate = TRUE)
+	if(H.is_species(SPECIES_IPC) && ishuman(user) && (user.zone_sel.selecting == BP_MOUTH || user.zone_sel.selecting == BP_HEAD))
+		var/obj/item/organ/internal/ecs/T = H.internal_organs_by_name[BP_EXONET]
+		T.computer.try_install_component(user, src)

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -95,7 +95,12 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 			. = min(., shared_living_nano_distance(src_object))
 		if(. == STATUS_UPDATE && (psi && !psi.suppressed && psi.get_rank(PSI_PSYCHOKINESIS) >= PSI_RANK_OPERANT))
 			return STATUS_INTERACTIVE
-		if(is_species(SPECIES_IPC))
-			var/obj/item/modular_computer/ecs/computer = src_object
-			if(computer.type == /obj/item/modular_computer/ecs)
+		var/dist = get_dist(src_object, src)
+		var/obj/item/modular_computer/ecs/computer = src_object
+		if(computer.type == /obj/item/modular_computer/ecs)
+			if(is_species(SPECIES_IPC) && dist == 0)
 				return STATUS_INTERACTIVE
+			else if (dist <= 3)
+				return STATUS_UPDATE
+			else
+				return STATUS_CLOSE

--- a/code/modules/organs/internal/exonet_connection_system.dm
+++ b/code/modules/organs/internal/exonet_connection_system.dm
@@ -75,3 +75,9 @@
 			return computer.open_terminal_ecs(user)
 		if("Emergency Shutdown")
 			return computer.emergency_shutdown(user)
+
+/mob/living/carbon/human/machine/attackby(var/obj/item/H as obj, var/mob/user as mob)
+	var/obj/item/organ/internal/ecs/T = src.internal_organs_by_name[BP_EXONET]
+	if(istype(H, /obj/item/stock_parts/computer/hard_drive/portable))
+		if(user.zone_sel.selecting == BP_MOUTH && user.a_intent == I_HELP)
+			T.computer.try_install_component(user, H)

--- a/code/modules/organs/internal/exonet_connection_system.dm
+++ b/code/modules/organs/internal/exonet_connection_system.dm
@@ -75,9 +75,3 @@
 			return computer.open_terminal_ecs(user)
 		if("Emergency Shutdown")
 			return computer.emergency_shutdown(user)
-
-/mob/living/carbon/human/machine/attackby(var/obj/item/H as obj, var/mob/user as mob)
-	var/obj/item/organ/internal/ecs/T = src.internal_organs_by_name[BP_EXONET]
-	if(istype(H, /obj/item/stock_parts/computer/hard_drive/portable))
-		if(user.zone_sel.selecting == BP_MOUTH && user.a_intent == I_HELP)
-			T.computer.try_install_component(user, H)

--- a/infinity/code/modules/mob/living/carbon/human/machine_limb_functions.dm
+++ b/infinity/code/modules/mob/living/carbon/human/machine_limb_functions.dm
@@ -1,5 +1,5 @@
 /datum/species/machine
-	inherent_verbs = list(/mob/living/carbon/human/proc/detach_limb, /mob/living/carbon/human/proc/attach_limb, /mob/living/carbon/human/proc/IPC_change_screen, /mob/living/carbon/human/proc/IPC_display_text, /mob/living/carbon/human/proc/IPC_toggle_off_screen, /mob/living/carbon/human/proc/enter_exonet, /mob/living/carbon/human/proc/show_exonet_screen)
+	inherent_verbs = list(/mob/living/carbon/human/proc/detach_limb, /mob/living/carbon/human/proc/attach_limb, /mob/living/carbon/human/proc/IPC_toggle_off_screen, /mob/living/carbon/human/proc/enter_exonet)
 
 /mob/living/carbon/human/proc/detach_limb()
 	set category = "Abilities"
@@ -221,11 +221,24 @@
 
 
 /mob/living/carbon/human/proc/update_ipc_verbs()
+	var/obj/item/organ/external/head/R = src.get_organ(BP_HEAD)
+	var/datum/robolimb/robohead = all_robolimbs[R.model]
 	var/obj/item/organ/internal/ecs/enter = src.internal_organs_by_name[BP_EXONET]
 	if(enter.computer.portable_drive)
 		src.verbs |= /mob/living/carbon/human/proc/ipc_eject_usb
 	else
 		src.verbs -= /mob/living/carbon/human/proc/ipc_eject_usb
+
+	if(robohead.is_monitor)
+		src.verbs |= /mob/living/carbon/human/proc/show_exonet_screen
+		src.verbs |= /mob/living/carbon/human/proc/IPC_change_screen
+		src.verbs |= /mob/living/carbon/human/proc/IPC_display_text
+	else
+		src.verbs -= /mob/living/carbon/human/proc/show_exonet_screen
+		src.verbs -= /mob/living/carbon/human/proc/IPC_change_screen
+		src.verbs -= /mob/living/carbon/human/proc/IPC_display_text
+
+
 
 /mob/living/carbon/human/proc/ipc_eject_usb()
 	set category = "Abilities"

--- a/infinity/code/modules/mob/living/carbon/human/machine_limb_functions.dm
+++ b/infinity/code/modules/mob/living/carbon/human/machine_limb_functions.dm
@@ -1,5 +1,5 @@
 /datum/species/machine
-	inherent_verbs = list(/mob/living/carbon/human/proc/detach_limb, /mob/living/carbon/human/proc/attach_limb, /mob/living/carbon/human/proc/IPC_change_screen, /mob/living/carbon/human/proc/IPC_display_text, /mob/living/carbon/human/proc/IPC_toggle_off_screen, /mob/living/carbon/human/proc/enter_exonet)
+	inherent_verbs = list(/mob/living/carbon/human/proc/detach_limb, /mob/living/carbon/human/proc/attach_limb, /mob/living/carbon/human/proc/IPC_change_screen, /mob/living/carbon/human/proc/IPC_display_text, /mob/living/carbon/human/proc/IPC_toggle_off_screen, /mob/living/carbon/human/proc/enter_exonet, /mob/living/carbon/human/proc/show_exonet_screen)
 
 /mob/living/carbon/human/proc/detach_limb()
 	set category = "Abilities"
@@ -189,3 +189,48 @@
 		return
 	else
 		enter.exonet(src)
+	update_ipc_verbs()
+
+/mob/living/carbon/human/proc/show_exonet_screen()
+	set category = "Abilities"
+	set name = "Show Exonet Screen"
+	set desc = ""
+	var/obj/item/organ/external/head/R = src.get_organ(BP_HEAD)
+	var/obj/item/organ/internal/ecs/enter = src.internal_organs_by_name[BP_EXONET]
+	var/datum/robolimb/robohead = all_robolimbs[R.model]
+
+	if(R.is_stump() || R.is_broken() || !R)
+		return
+
+	if(!enter)
+		to_chat(usr, "<span class='warning'>You have no exonet connection port</span>")
+		return
+	if(robohead.is_monitor)
+		var/obj/item/I = enter.computer
+		I.showscreen(src)
+		f_style = "Database"
+		update_hair()
+		var/mob/M
+		robohead.display_text = "<a HREF=?src=\ref[M];showipcscreen=\ref[src]>Take a closer look.</a>"
+	else
+		to_chat(usr, "<span class='warning'>Your head has no screen!</span>")
+
+/obj/item/proc/showscreen(mob/user)
+	for (var/mob/M in view(user))
+		M.show_message("[user] changes image on his screen. <a HREF=?src=\ref[M];showipcscreen=\ref[src]>Take a closer look.</a>",1)
+
+
+/mob/living/carbon/human/proc/update_ipc_verbs()
+	var/obj/item/organ/internal/ecs/enter = src.internal_organs_by_name[BP_EXONET]
+	if(enter.computer.portable_drive)
+		src.verbs |= /mob/living/carbon/human/proc/ipc_eject_usb
+	else
+		src.verbs -= /mob/living/carbon/human/proc/ipc_eject_usb
+
+/mob/living/carbon/human/proc/ipc_eject_usb()
+	set category = "Abilities"
+	set name = "Eject Data Crystal"
+	set desc = ""
+	var/obj/item/organ/internal/ecs/enter = src.internal_organs_by_name[BP_EXONET]
+	enter.computer.uninstall_component(usr, enter.computer.portable_drive)
+	update_ipc_verbs()

--- a/infinity/code/modules/mob/living/carbon/human/machine_limb_functions.dm
+++ b/infinity/code/modules/mob/living/carbon/human/machine_limb_functions.dm
@@ -210,8 +210,6 @@
 		I.showscreen(src)
 		f_style = "Database"
 		update_hair()
-		var/mob/M
-		robohead.display_text = "<a HREF=?src=\ref[M];showipcscreen=\ref[src]>Take a closer look.</a>"
 	else
 		to_chat(usr, "<span class='warning'>Your head has no screen!</span>")
 


### PR DESCRIPTION
# Описание

ИПС смогут через кнопку в абилити панели выводить изображение их компьютера, на головной монитор. Другие через нажатие на ссылку в чате, смогут видеть что показывает ИПС.

ИПС сможет вставлять и удалять флешку из своего компьютера в голове. Для этого собственно нужна флешка, и нацелится на рот/голову


## Changelog
:cl:
rscadd: Добавлена возможность выводить изображение с экрана ИПСа, для наблюдения окружающих.
rscadd: Добавлена возможность вставлять флешки в компьютер ИПСа
/:cl:
