### PR TITLE
Fix High Pulse Electricity Outage Tool

### DIFF
--- a/infinity/code/game/objects/items/devices/blackout.dm
+++ b/infinity/code/game/objects/items/devices/blackout.dm
@@ -63,7 +63,7 @@
 		shots--
 		Cooldown = world.time
 
-	//	power_failure(1, 2, GetConnectedZlevels(P.z))
+		power_failure(1, severity, GetConnectedZlevels(user.z))
 
 		var/datum/powernet/powernet = terminal_in.powernet
 		for(var/obj/machinery/power/terminal/terminal_out in powernet.nodes)


### PR DESCRIPTION
# Описание

Пофиксил High Pulse Electricity Outage Tool. Теперь оно работает как и задумывалось.

## Changelog

<!-- С помощью этого раздела можно подготовить список изменений, которые попадут в игровой чейндж-лог. --->
<!-- Вам нужно указать префикс изменения (Он идёт до двоеточия) и дать описание, как на примере. --->
<!-- Префиксы можно использовать несколько раз. --->
<!-- Если Вы не планируете добавлять записи в чейндж-лог - просто удалите из пулл-реквеста этот раздел. --->

:cl:
bugfix: High Pulse Electricity Outage Tool теперь работает согласно описанию
/:cl:
